### PR TITLE
Give app_version a value in custom builds

### DIFF
--- a/vars.config
+++ b/vars.config
@@ -29,6 +29,7 @@
 {runner_user,           ""}.
 {runner_wait_process,   "vmq_cluster_node_sup"}.
 {runner_ulimit_warn,    65536}.
+{app_version,           "$(git describe --tag --dirty)"}.
 
 %% vmq_server
 {max_connections, 10000}.

--- a/vars/dev_vars.config.src
+++ b/vars/dev_vars.config.src
@@ -29,6 +29,7 @@
 {runner_user,           ""}.
 {runner_wait_process,   "vmq_cluster_node_sup"}.
 {runner_ulimit_warn,    65536}.
+{app_version,           "$(git describe --tag --dirty)"}.
 
 %% vmq_server
 {max_connections, 10000}.


### PR DESCRIPTION
This value is getting set in other ways when creating packages.

This means `vernemq version` will now return a string like
'0.14.2-03f5c05' instead of the empty string.
