### PR TITLE
Build packages without a _checkouts folder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -248,9 +248,9 @@ prep_dirty_package:
 	rsync -a . /tmp/vernemq-dirty-package --exclude distdir
 	mkdir -p distdir
 	cp -aR /tmp/vernemq-dirty-package distdir/$(PKG_ID)
-	if [ -d distdir/$(PKG_ID)/_checkouts ]; then \
+	if [ -d "distdir/$(PKG_ID)/_checkouts" ]; then \
 	  for co in distdir/$(PKG_ID)/_checkouts/* ; do \
-	     mv $${co} distdir/$(PKG_ID)/_build/default/lib/; \
+	     cp -R $${co} distdir/$(PKG_ID)/_build/default/lib/; \
 	  done \
 	fi
 	for dep in distdir/$(PKG_ID)/_build/default/lib/*; do \

--- a/Makefile
+++ b/Makefile
@@ -248,9 +248,11 @@ prep_dirty_package:
 	rsync -a . /tmp/vernemq-dirty-package --exclude distdir
 	mkdir -p distdir
 	cp -aR /tmp/vernemq-dirty-package distdir/$(PKG_ID)
-	for co in distdir/$(PKG_ID)/_checkouts/* ; do \
-	   mv $${co} distdir/$(PKG_ID)/_build/default/lib/; \
-	done
+	if [ -d distdir/$(PKG_ID)/_checkouts ]; then \
+	  for co in distdir/$(PKG_ID)/_checkouts/* ; do \
+	     mv $${co} distdir/$(PKG_ID)/_build/default/lib/; \
+	  done \
+	fi
 	for dep in distdir/$(PKG_ID)/_build/default/lib/*; do \
 	    mkdir -p $${dep}/priv; \
 	    cd $${dep}; \


### PR DESCRIPTION
This is useful when upgrading dependencies but not wanting to commit the
changes yet.