### PR TITLE
Add cover for all repos

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -32,6 +32,8 @@
               ]}
             ]}.
 
+{cover_enabled, true}.
+
 {profiles,
  [{rpi32,
    [{deps,


### PR DESCRIPTION
Otherwise it's not possible to run the individual vmq_server ct tests as they expect the cover app to be started.