### PR TITLE
Fix racing subscriber test

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -32,6 +32,8 @@
               ]}
             ]}.
 
+{cover_enabled, true}.
+
 {profiles,
  [{rpi32,
    [{deps,


### PR DESCRIPTION
This builds on top of #227 and that PR should be merged before this.

The racing subscriber test was sometimes failing. I noticed that it was because the `vmq_subscriber:subtract/3` was sometimes called with the second argument empty (`[]`) which we don't handle. See the details in the commit.

The fix relies on the two lists to `get_changes/2` to be sorted. I haven't been able to verify if they indeed are sure, but I couldn't imagine how the implementation of `subtract` would ever work in the first place if they aren't.