### PR TITLE
Make random tests reproducible via a seed

### DIFF
--- a/apps/vmq_server/test/vmq_cluster_netsplit_SUITE.erl
+++ b/apps/vmq_server/test/vmq_cluster_netsplit_SUITE.erl
@@ -21,9 +21,9 @@
 %% ===================================================================
 %% common_test callbacks
 %% ===================================================================
-init_per_suite(_Config) ->
+init_per_suite(Config) ->
+    S = vmq_test_utils:get_suite_rand_seed(),
     lager:start(),
-    {ok, rnd} = rand_compat:init(),
     %% this might help, might not...
     os:cmd(os:find_executable("epmd")++" -daemon"),
     {ok, Hostname} = inet:gethostname(),
@@ -32,13 +32,14 @@ init_per_suite(_Config) ->
         {error, {already_started, _}} -> ok
     end,
     lager:info("node name ~p", [node()]),
-    _Config.
+    [S | Config].
 
 end_per_suite(_Config) ->
     application:stop(lager),
     _Config.
 
 init_per_testcase(Case, Config) ->
+    vmq_test_utils:seed_rand(Config),
     Nodes = vmq_cluster_test_utils:pmap(
               fun({N, P}) ->
                       Node = vmq_cluster_test_utils:start_node(N, Config, Case),

--- a/apps/vmq_server/test/vmq_lvldb_store_SUITE.erl
+++ b/apps/vmq_server/test/vmq_lvldb_store_SUITE.erl
@@ -16,8 +16,8 @@
 %% ===================================================================
 %% common_test callbacks
 %% ===================================================================
-init_per_suite(_Config) ->
-    {ok, rnd} = rand_compat:init(),
+init_per_suite(Config) ->
+    S = vmq_test_utils:get_suite_rand_seed(),
     %% this might help, might not...
     os:cmd(os:find_executable("epmd")++" -daemon"),
     case net_kernel:start([lvldb_test, shortnames]) of
@@ -25,13 +25,13 @@ init_per_suite(_Config) ->
         {error, _} -> ok
     end,
     cover:start(),
-    _Config.
+    [S|Config].
 
 end_per_suite(_Config) ->
     _Config.
 
 init_per_testcase(_Case, Config) ->
-    rnd:seed(os:timestamp()),
+    vmq_test_utils:seed_rand(Config),
     vmq_test_utils:setup(),
     Config.
 
@@ -170,8 +170,8 @@ ref_delete_test(Config) ->
 generate_msgs(0, Acc) -> Acc;
 generate_msgs(N, Acc) ->
     Msg = #vmq_msg{msg_ref=vmq_mqtt_fsm:msg_ref(),
-                   routing_key=crypto:strong_rand_bytes(10),
-                   payload = crypto:strong_rand_bytes(100),
+                   routing_key=vmq_test_utils:rand_bytes(10),
+                   payload = vmq_test_utils:rand_bytes(100),
                    mountpoint = "",
                    dup = random_flag(),
                    qos = random_qos(),

--- a/apps/vmq_server/test/vmq_publish_SUITE.erl
+++ b/apps/vmq_server/test/vmq_publish_SUITE.erl
@@ -32,14 +32,16 @@
 %% ===================================================================
 %% common_test callbacks
 %% ===================================================================
-init_per_suite(_Config) ->
+init_per_suite(Config) ->
+    S = vmq_test_utils:get_suite_rand_seed(),
     cover:start(),
-    _Config.
+    [S|Config].
 
 end_per_suite(_Config) ->
     _Config.
 
 init_per_testcase(_Case, Config) ->
+    vmq_test_utils:seed_rand(Config),
     vmq_test_utils:setup(),
     vmq_server_cmd:set_config(allow_anonymous, true),
     vmq_server_cmd:set_config(retry_interval, 10),
@@ -423,7 +425,7 @@ message_size_exceeded_close(_) ->
     vmq_config:set_env(message_size_limit, 1024, false),
     Connect = packet:gen_connect("pub-excessive-test", [{keepalive, 60}]),
     Connack = packet:gen_connack(0),
-    Publish = packet:gen_publish("pub/excessive/test", 0, crypto:strong_rand_bytes(1024),
+    Publish = packet:gen_publish("pub/excessive/test", 0, vmq_test_utils:rand_bytes(1024),
                                  [{mid, 19}]),
     {ok, Socket} = packet:do_client_connect(Connect, Connack, []),
     enable_on_publish(),

--- a/apps/vmq_server/test/vmq_rate_limiter_SUITE.erl
+++ b/apps/vmq_server/test/vmq_rate_limiter_SUITE.erl
@@ -16,14 +16,16 @@
 %% ===================================================================
 %% common_test callbacks
 %% ===================================================================
-init_per_suite(_Config) ->
+init_per_suite(Config) ->
+    S = vmq_test_utils:get_suite_rand_seed(),
     cover:start(),
-    _Config.
+    [S|Config].
 
 end_per_suite(_Config) ->
     _Config.
 
 init_per_testcase(_Case, Config) ->
+    vmq_test_utils:seed_rand(Config),
     vmq_test_utils:setup(),
     vmq_server_cmd:set_config(retry_interval, 10),
     vmq_server_cmd:set_config(allow_anonymous, false),
@@ -46,7 +48,7 @@ publish_rate_limit_test(_) ->
     Connack = packet:gen_connack(0),
     Pub = fun(Sleep, Socket, Id) ->
                   Publish = packet:gen_publish("rate/limit/test", 1,
-                                               crypto:strong_rand_bytes(1460), [{mid, Id}]),
+                                               vmq_test_utils:rand_bytes(1460), [{mid, Id}]),
                   Puback = packet:gen_puback(Id),
                   ok = gen_tcp:send(Socket, Publish),
                   ok = packet:expect_packet(Socket, "puback", Puback),


### PR DESCRIPTION
This introduces a couple of helper functions:

     vmq_test_utils:get_suite_rand_seed/0

Generates a seed from `os:timestamp()` for the entire suite if one is
not set via `{seed, Seed}.` in a config file passed to CT. This function
should be called from the `init_per_suite/1` function and the seed
returned should be added to the CT `Config` list. The seed will be
printed to console.

     vmq_test_utils:seed_rand/1

Is for use in the individual test cases to seed the rng.

     vmq_test_utils:rand_bytes/1

This replaces the use of `crypto:strong_rand_bytes` in tests so random
bytes will be deterministically drawn according to the seed.