### PR TITLE
Fix retain case_clause bug

### DIFF
--- a/apps/vmq_server/src/vmq_retain_srv.erl
+++ b/apps/vmq_server/src/vmq_retain_srv.erl
@@ -125,7 +125,7 @@ init([]) ->
       fun({MPTopic, '$deleted'}, _) ->
               ets:delete(?RETAIN_CACHE, MPTopic);
          ({MPTopic, Msg}, _) ->
-              ets:insert(?RETAIN_CACHE, [{MPTopic, Msg, false}])
+              ets:insert(?RETAIN_CACHE, [{MPTopic, Msg}])
       end, ok, ?RETAIN_DB, [{resolver, lww}]),
     erlang:send_after(vmq_config:get_env(retain_persist_interval, 1000),
                       self(), persist),
@@ -175,7 +175,7 @@ handle_info({deleted, ?RETAIN_DB, Key, _Val}, State) ->
     ets:delete(?RETAIN_CACHE, Key),
     {noreply, State};
 handle_info({updated, ?RETAIN_DB, Key, _OldVal, NewVal}, State) ->
-    ets:insert(?RETAIN_CACHE, {Key, NewVal, false}),
+    ets:insert(?RETAIN_CACHE, {Key, NewVal}),
     {noreply, State};
 handle_info(persist, State) ->
     ets:foldl(fun persist/2, ignore, ?RETAIN_UPDATE),


### PR DESCRIPTION
When introducing the new retain cache/update method two cases of the old format
was missed and left behind.

Fixes erlio/vernemq#236.