### PR TITLE
Fix another issue in the parser logic

### DIFF
--- a/apps/vmq_commons/src/vmq_parser.erl
+++ b/apps/vmq_commons/src/vmq_parser.erl
@@ -67,12 +67,15 @@ parse(DataSize, 0, Fixed, Data) when byte_size(Data) >= DataSize ->
     %% no max size limit
     <<Var:DataSize/binary, Rest/binary>> = Data,
     {variable(Fixed, Var), Rest};
+parse(DataSize, 0, Fixed, Data) when byte_size(Data) < DataSize ->
+    more;
 parse(DataSize, MaxSize, Fixed, Data)
   when byte_size(Data) >= DataSize,
        byte_size(Data) =< MaxSize ->
     <<Var:DataSize/binary, Rest/binary>> = Data,
     {variable(Fixed, Var), Rest};
-parse(DataSize, MaxSize, _, _) when DataSize > MaxSize ->
+parse(DataSize, MaxSize, _, _)
+  when DataSize > MaxSize ->
     {error, packet_exceeds_max_size};
 parse(_, _, _, _) -> more.
 


### PR DESCRIPTION
As reported by @waliferus on slack:

When fixing the last parser issue, we inadvertently changed the logic so
parse/4 would be returning `packet_exceeds_max_size` when `MaxSize=0`
and `byte_size(Data) < DataSize` which of course makes no sense.

This commits makes sure we handle all six cases:

- no max, enough data -> parse
- no max, not enough data -> more
- max - enough data - max exceeded -> error max exceeded
- max - enough data - max not exceeded -> parse
- max - not enough data - max exceeded -> error max exceeded
- max - not enough data - max not exceeded -> more

@dergraf please review