### PR TITLE
Subscriber groups/shared subscriptions

### DIFF
--- a/Readme.rst
+++ b/Readme.rst
@@ -32,6 +32,7 @@ VerneMQ implements the MQTT 3.1 and 3.1.1 specifications. Currently the followin
 * Extensible Plugin architecture
 * Multiple Sessions per ClientId
 * Session Balancing
+* Shared Subscriptions
 * Message load regulation
 * Message load shedding (for system protection)
 * Offline Message Storage (based on LevelDB)

--- a/Readme.rst
+++ b/Readme.rst
@@ -32,7 +32,7 @@ VerneMQ implements the MQTT 3.1 and 3.1.1 specifications. Currently the followin
 * Extensible Plugin architecture
 * Multiple Sessions per ClientId
 * Session Balancing
-* Shared Subscriptions
+* Shared subscriptions (BETA)
 * Message load regulation
 * Message load shedding (for system protection)
 * Offline Message Storage (based on LevelDB)

--- a/apps/vmq_server/priv/vmq_server.schema
+++ b/apps/vmq_server/priv/vmq_server.schema
@@ -1460,3 +1460,12 @@
          {ok, Term} = erl_parse:parse_term(T),
          Term
  end}.
+
+%% @doc Distribution policy for shared subscriptions. Default is
+%% 'prefer_local' which will ensure that local subscribers will be
+%% used if any are available. 'random' will randomly choose between
+%% all available subscribers.
+{mapping, "shared_subscription_policy", "vmq_server.shared_subscription_policy", [
+                                                                                  {default, prefer_local},
+                                                                                  {datatype, atom}
+                                                                                 ]}.

--- a/apps/vmq_server/src/vmq_cluster.erl
+++ b/apps/vmq_server/src/vmq_cluster.erl
@@ -14,6 +14,8 @@
 
 -module(vmq_cluster).
 
+-include_lib("vmq_commons/include/vmq_types.hrl").
+
 -behaviour(gen_event).
 
 %% gen_server callbacks
@@ -90,6 +92,10 @@ publish(Node, Msg) ->
             vmq_cluster_node:publish(Pid, Msg)
     end.
 
+-spec remote_enqueue(node(), Term)
+        -> {ok, pid()} | {error, term()}
+        when Term::{enqueue_many, subscriber_id(), Msgs::term(), Opts::list()}
+                 | {enqueue, Queue::term(), Msgs::term()}.
 remote_enqueue(Node, Term) ->
     case vmq_cluster_node_sup:get_cluster_node(Node) of
         {error, not_found} ->

--- a/apps/vmq_server/src/vmq_cluster_node.erl
+++ b/apps/vmq_server/src/vmq_cluster_node.erl
@@ -67,7 +67,6 @@ enqueue(Pid, Term) ->
             {error, Reason}
     end.
 
-
 init([Parent, RemoteNode]) ->
     MaxQueueSize = vmq_config:get_env(outgoing_clustering_buffer_size),
     proc_lib:init_ack(Parent, {ok, self()}),

--- a/apps/vmq_server/src/vmq_config_cli.erl
+++ b/apps/vmq_server/src/vmq_config_cli.erl
@@ -48,7 +48,8 @@ register_config_() ->
      "graphite_enabled",
      "graphite_host",
      "graphite_port",
-     "graphite_interval"
+     "graphite_interval",
+     "shared_subscription_policy"
     ],
     _ = [clique:register_config([Key], fun register_config_callback/3)
          || Key <- ConfigKeys],

--- a/apps/vmq_server/src/vmq_server.hrl
+++ b/apps/vmq_server/src/vmq_server.hrl
@@ -1,6 +1,7 @@
 -include_lib("vmq_commons/include/vmq_types.hrl").
 -type plugin_id()       :: {plugin, atom(), pid()}.
 
+-type sg_policy() :: prefer_local | random.
 -record(vmq_msg, {
           msg_ref               :: msg_ref(),
           routing_key           :: routing_key(),
@@ -9,6 +10,7 @@
           dup=false             :: flag(),
           qos                   :: qos(),
           mountpoint            :: mountpoint(),
-          persisted=false       :: flag()
+          persisted=false       :: flag(),
+          sg_policy=prefer_local:: sg_policy()
          }).
 -type msg()             :: #vmq_msg{}.

--- a/apps/vmq_server/src/vmq_systree.erl
+++ b/apps/vmq_server/src/vmq_systree.erl
@@ -119,7 +119,8 @@ handle_info(timeout, true) ->
             MsgTmpl = #vmq_msg{
                          mountpoint=vmq_config:get_env(systree_mountpoint, ""),
                          qos=vmq_config:get_env(systree_qos, 0),
-                         retain=vmq_config:get_env(systree_retain, false)
+                         retain=vmq_config:get_env(systree_retain, false),
+                         sg_policy=vmq_config:get_env(shared_subscription_policy, prefer_local)
                         },
             lists:foreach(
               fun({_Type, Metric, Val}) ->

--- a/apps/vmq_server/test/vmq_cluster_SUITE.erl
+++ b/apps/vmq_server/test/vmq_cluster_SUITE.erl
@@ -14,7 +14,9 @@
          racing_connect_test/1,
          racing_subscriber_test/1,
          cluster_leave_test/1,
-         cluster_leave_dead_node_test/1]).
+         cluster_leave_dead_node_test/1,
+         shared_subs_random_policy_test/1,
+         shared_subs_prefer_local_policy_test/1]).
 
 -export([hook_uname_password_success/5,
          hook_auth_on_publish/6,
@@ -69,12 +71,15 @@ end_per_testcase(_, _Config) ->
 
 all() ->
     [multiple_connect_test
-     ,multiple_connect_unclean_test
-     , distributed_subscribe_test
-     , racing_connect_test
-     , racing_subscriber_test
-     , cluster_leave_test
-     , cluster_leave_dead_node_test].
+    ,multiple_connect_unclean_test
+    ,distributed_subscribe_test
+    ,racing_connect_test
+    ,racing_subscriber_test
+    ,cluster_leave_test
+    ,cluster_leave_dead_node_test
+    ,shared_subs_random_policy_test
+    ,shared_subs_prefer_local_policy_test
+    ].
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -418,6 +423,155 @@ cluster_leave_dead_node_test(Config) ->
                                       rpc:call(N, vmq_queue_sup_sup, summary, [])
                               end, {0, 0, 0, 5, 0}).
 
+shared_subs_prefer_local_policy_test(Config) ->
+    ensure_cluster(Config),
+    [LocalNode|OtherNodes] = Nodes = nodes_(Config),
+    set_shared_subs_policy(prefer_local, nodenames(Config)),
+
+    LocalSubscriberSockets = connect_shared_subscribers(<<"$share/share/sharedtopic">>, 5, [LocalNode]),
+    RemoteSubscriberSockets = connect_shared_subscribers(<<"$share/share/sharedtopic">>, 5, OtherNodes),
+    
+    %% Make sure subscriptions have propagated to all nodes
+    ok = wait_until_converged(Nodes,
+                              fun(N) ->
+                                      rpc:call(N, vmq_reg, total_subscriptions, [])
+                              end, [{total, 10}]),
+
+    %% publish to shared topic on local node
+    {_, LocalPort} = LocalNode,
+    Connect = packet:gen_connect("ss-publisher",
+                                 [{keepalive, 60}, {clean_session, true}]),
+    Connack = packet:gen_connack(0),
+    {ok, Socket} = packet:do_client_connect(Connect, Connack, [{port, LocalPort}]),
+    Payloads = publish_to_shared_topic(Socket, <<"sharedtopic">>, 10),
+    Disconnect = packet:gen_disconnect(),
+    ok = gen_tcp:send(Socket, Disconnect),
+    ok = gen_tcp:close(Socket),
+
+    %% receive on subscriber sockets.
+    receive_shared_sub_messages(LocalSubscriberSockets, Payloads),
+    receive_nothing(200),
+    receive_shared_sub_messages(RemoteSubscriberSockets, []),
+    receive_nothing(200),
+
+    %% cleanup
+    [ ok = gen_tcp:close(S) || S <- LocalSubscriberSockets ++ RemoteSubscriberSockets ],
+    ok.
+
+shared_subs_random_policy_test(Config) ->
+    ensure_cluster(Config),
+    Nodes = nodes_(Config),
+    set_shared_subs_policy(random, nodenames(Config)),
+
+    SubscriberSockets = connect_shared_subscribers(<<"$share/share/sharedtopic">>, 10, Nodes),
+
+    %% Make sure subscriptions have propagated to all nodes
+    ok = wait_until_converged(Nodes,
+                              fun(N) ->
+                                      rpc:call(N, vmq_reg, total_subscriptions, [])
+                              end, [{total, 10}]),
+
+    %% publish to shared topic on random node
+    {_, Port} = random_node(Nodes),
+    Connect = packet:gen_connect("ss-publisher",
+                                 [{keepalive, 60}, {clean_session, true}]),
+    Connack = packet:gen_connack(0),
+    {ok, Socket} = packet:do_client_connect(Connect, Connack, [{port, Port}]),
+    Payloads = publish_to_shared_topic(Socket, <<"sharedtopic">>, 10),
+    Disconnect = packet:gen_disconnect(),
+    ok = gen_tcp:send(Socket, Disconnect),
+    ok = gen_tcp:close(Socket),
+
+    %% receive on subscriber sockets.
+    receive_shared_sub_messages(SubscriberSockets, Payloads),
+    receive_nothing(200),
+    
+    %% cleanup
+    [ ok = gen_tcp:close(S) || S <- SubscriberSockets ],
+    ok.
+
+connect_shared_subscribers(Topic, Number, Nodes) ->
+    [begin
+         
+         {_, Port} = random_node(Nodes),
+         Connect = packet:gen_connect("ss-subscriber-" ++ integer_to_list(I) ++ "-node-" ++ 
+                                          integer_to_list(Port),
+                                      [{keepalive, 60}, {clean_session, true}]),
+         Connack = packet:gen_connack(0),
+         Subscribe = packet:gen_subscribe(1, [Topic], 1),
+         Suback = packet:gen_suback(1, 1),
+         %% TODO: make it connect to random node instead
+         {ok, Socket} = packet:do_client_connect(Connect, Connack, [{port, Port}]),
+         ok = gen_tcp:send(Socket, Subscribe),
+         ok = packet:expect_packet(Socket, "suback", Suback),
+         Socket
+     end || I <- lists:seq(1,Number)].
+
+publish_to_shared_topic(Socket, Topic, Number) ->
+    [begin
+         Payload = vmq_test_utils:rand_bytes(5),
+         Publish = packet:gen_publish(Topic, 1, Payload, [{mid, I}]),
+         Puback = packet:gen_puback(I),
+         ok = gen_tcp:send(Socket, Publish),
+         ok = packet:expect_packet(Socket, "puback", Puback),
+         Payload
+     end || I <- lists:seq(1,Number)].
+
+set_shared_subs_policy(Policy, Nodes) ->
+    lists:foreach(
+      fun(N) ->
+              {ok, []} = rpc:call(N, vmq_server_cmd, set_config, [shared_subscription_policy, Policy])
+      end,
+      Nodes).
+
+nodenames(Config) ->
+    {NodeNames, _} = lists:unzip(nodes_(Config)),
+    NodeNames.
+
+nodes_(Config) ->
+    {_, Nodes} = lists:keyfind(nodes, 1, Config),
+    Nodes.
+    
+receive_shared_sub_messages(ReceiverSockets, Payloads) ->
+    Master = self(),
+    _RecProcs =
+        lists:foreach(
+          fun(S) ->
+                  spawn_link(fun() -> recv_and_forward_msg(S, Master, <<>>) end)
+          end,
+          ReceiverSockets),
+    receive_shared_sub_messages(Payloads).
+
+receive_shared_sub_messages([]) ->
+    ok;
+receive_shared_sub_messages(Payloads) ->
+    receive
+        #mqtt_publish{payload=Payload} ->
+            true = lists:member(Payload, Payloads),
+            receive_shared_sub_messages(Payloads -- [Payload])
+    end.
+
+receive_nothing(Wait) ->
+    receive
+        X -> throw({received_unexpected_msgs, X})
+    after
+        Wait -> ok
+    end.
+
+recv_and_forward_msg(Socket, Dest, Rest) ->
+    case recv_all(Socket, Rest) of
+        {ok, Frames, Rest} ->
+            lists:foreach(
+              fun(#mqtt_publish{message_id = MsgId} = Msg) ->
+                      ok = gen_tcp:send(Socket, packet:gen_puback(MsgId)),
+                      Dest ! Msg
+              end,
+              Frames),
+            recv_and_forward_msg(Socket, Dest, Rest);
+        {error, _Reason} ->
+            ok
+    end.
+
 publish(Nodes, NrOfProcesses, NrOfMsgsPerProcess) ->
     publish(self(), Nodes, NrOfProcesses, NrOfMsgsPerProcess, []).
 
@@ -481,22 +635,36 @@ receive_publishes([{_,Port}=N|Nodes], Topic, Payloads) ->
     end.
 
 recv(Socket, Buf) ->
+    case recv_all(Socket, Buf) of
+        {ok, [], Rest} ->
+            recv_all(Socket, Rest);
+        {ok, [Frame|_], _Rest} ->
+            {ok, Frame};
+        E -> E
+    end.
+
+recv_all(Socket, Buf) ->
     case gen_tcp:recv(Socket, 0) of
         {ok, Data} ->
             NewData = <<Buf/binary, Data/binary>>,
-            case vmq_parser:parse(NewData) of
-                more ->
-                    recv(Socket, NewData);
-                {error, _Rest} ->
-                    {error, parse_error};
-                error ->
-                    {error, parse_error};
-                {Frame, _Rest} ->
-                    {ok, Frame}
-            end;
+            parse_all(NewData);
         {error, Reason} -> {error, Reason}
     end.
 
+parse_all(Data) ->
+    parse_all(Data, []).
+
+parse_all(Data, Frames) ->
+    case vmq_parser:parse(Data) of
+        more ->
+            {ok, lists:reverse(Frames), Data};
+        {error, _Rest} ->
+            {error, parse_error};
+        error ->
+            {error, parse_error};
+        {Frame, Rest} ->
+            parse_all(Rest, [Frame|Frames])
+    end.
 
 
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## Nightly (will become next release)
+
+### vmq_server
+
+- Add implementation of shared subscriptions as specified in the MQTTv5 draft
+  spec. Currently two different distribution policies are supported:
+
+  - `prefer_local` which will, if possible, deliver the message to a random
+    local subscriber in the shared subscription group, otherwise the message
+    will be delivered to a random remote subscriber of the shared
+    subscription (if any).
+  - `random` will distribute the messages random between all members of the
+    shared supscription regardless if they are local or are subscribed via
+    another node.
+
+  Currently, only members of the shared subscription that are online are
+  eligible as receivers of shared subscription messages. This means it's
+  currently not possible to have the messages stored as offline messages. We may
+  change this semantics in the future and because of this and because of the
+  fact that the MQTTv5 is not yet final, this feature is marked as BETA.
+
+  NOTE: To upgrade a live cluster all nodes must already be running 0.15.3 or
+  never! This feature is incompatible with older releases.
+
 ## VERNEMQ 0.15.3
 
 ### vmq_server


### PR DESCRIPTION
@dergraf Ready for review

 - policies implemented: `random` and `prefer_local`. We could consider adding `only_local` as well.
 - enqueue_many with options only implemented in 'online' state. Should probably be implemented in others as well?
 - needs to be verified against the MQTTv5 spec.
 - must be squashed before merging.