### PR TITLE
Subscriber groups online first

### DIFF
--- a/apps/vmq_server/priv/vmq_server.schema
+++ b/apps/vmq_server/priv/vmq_server.schema
@@ -1463,8 +1463,9 @@
 
 %% @doc Distribution policy for shared subscriptions. Default is
 %% 'prefer_local' which will ensure that local subscribers will be
-%% used if any are available. 'random' will randomly choose between
-%% all available subscribers.
+%% used if any are available. 'local_only' will select a random local
+%% subscriber if any are available. 'random' will randomly choose
+%% between all available subscribers.
 {mapping, "shared_subscription_policy", "vmq_server.shared_subscription_policy", [
                                                                                   {default, prefer_local},
                                                                                   {datatype, atom}

--- a/apps/vmq_server/src/shared_subscriptions.erl
+++ b/apps/vmq_server/src/shared_subscriptions.erl
@@ -1,0 +1,96 @@
+%% Copyright 2017 Erlio GmbH Basel Switzerland (http://erl.io)
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+-module(shared_subscriptions).
+
+-export([publish/3]).
+
+publish(_,_, undefined) -> ok;
+publish(Msg, Policy, SubscriberGroups) when is_map(SubscriberGroups) ->
+    publish(Msg, Policy, maps:to_list(SubscriberGroups));
+publish(_,_, []) -> ok;
+publish(Msg, Policy, [{Group, []}|Rest]) ->
+    lager:debug("can't publish to shared subscription ~p, no subscribers: ~p", [Group, Msg]),
+    publish(Msg, Policy, Rest);
+publish(Msg, Policy, [{Group, SubscriberGroup}|Rest]) ->
+    Subscribers = filter_subscribers(SubscriberGroup, Policy),
+    %% Randomize subscribers once.
+    RandSubscribers = [S||{_,S} <- lists:sort([{rnd:uniform(), N} || N <- Subscribers])],
+    case publish_to_group(Msg, RandSubscribers) of
+        ok ->
+            publish(Msg, Policy, Rest);
+        {error, Reason} ->
+            lager:debug("can't publish to shared subscription ~p due to '~p': Msg",
+                        [Group, Reason, Msg]),
+            publish(Msg, Policy, Rest)
+    end.
+
+publish_to_group(Msg, Subscribers) ->
+    case publish_online(Msg, Subscribers) of
+        ok ->
+            ok;
+        NotOnlineSubscribers ->
+            publish_any(Msg, NotOnlineSubscribers)
+    end.
+
+publish_online(Msg, Subscribers) ->
+    try
+        lists:foldl(
+          fun(Subscriber, Acc) ->
+                  case publish_(Msg, Subscriber, online) of
+                      ok ->
+                          throw(done);
+                      {error, offline} ->
+                          [Subscriber|Acc];
+                      {error, draining} ->
+                          [Subscriber|Acc];
+                      _ ->
+                          Acc
+                  end
+          end, Subscribers, [])
+    catch
+        done -> ok
+    end.
+
+publish_any(_Msg, []) -> {error, no_subscribers};
+publish_any(Msg, [Subscriber|Subscribers]) ->
+    case publish_(Msg, Subscriber, any) of
+        ok ->
+            ok;
+        {error, _} ->
+            publish_any(Msg, Subscribers)
+    end.
+
+publish_(Msg, {Node, SubscriberId, QoS}, QState) when Node == node() ->
+    case vmq_reg:get_queue_pid(SubscriberId) of
+        not_found ->
+            {error, not_found};
+        QPid ->
+            vmq_queue:enqueue_many(QPid, [{deliver, QoS, Msg}], #{states => [QState]})
+    end;
+publish_(Msg, {Node, SubscriberId, QoS}, QState) ->
+    Term = {enqueue_many, SubscriberId, [{deliver, QoS, Msg}], #{states => [QState]}},
+    vmq_cluster:remote_enqueue(Node, Term).
+
+filter_subscribers(Subscribers, random) ->
+    Subscribers;
+filter_subscribers(Subscribers, prefer_local) ->
+    Node = node(),
+    LocalSubscribers =
+        lists:filter(fun({N, _, _}) when N == Node -> true;
+                        (_) -> false
+                     end, Subscribers),
+    case LocalSubscribers of
+        [] -> Subscribers;
+        _ -> LocalSubscribers
+    end.

--- a/apps/vmq_server/src/vmq_server.hrl
+++ b/apps/vmq_server/src/vmq_server.hrl
@@ -1,7 +1,7 @@
 -include_lib("vmq_commons/include/vmq_types.hrl").
 -type plugin_id()       :: {plugin, atom(), pid()}.
 
--type sg_policy() :: prefer_local | random.
+-type sg_policy() :: prefer_local | local_only | random.
 -record(vmq_msg, {
           msg_ref               :: msg_ref(),
           routing_key           :: routing_key(),


### PR DESCRIPTION
This pull request makes sure that messages published to a shared subscription are first attempted to be delivered subscribers with queues that are online first and only afterwards to to non-online queues.

Further, it implements the `local_only` policy.