### PR TITLE
Support vmq-admin usage lead lines for plugins

### DIFF
--- a/apps/vmq_diversity/priv/vmq_diversity.schema
+++ b/apps/vmq_diversity/priv/vmq_diversity.schema
@@ -1,3 +1,6 @@
+%% -*- mode: erlang -*-
+%% ex: ft=erlang
+
 %% @doc Enable to keep the Lua state between calls. This would allow to
 %% to set global variables and reuse them in a later callback call or 
 %% even in a different callback. Default is 'off' enabling that no Lua
@@ -40,3 +43,8 @@
                || SortName <- ScriptNames ],
          lists:keysort(1, Scripts)
  end}.
+
+{mapping, "vmq_diversity.clique_lead_line", "vmq_diversity.clique_lead_line",
+ [{datatype, string},
+  hidden,
+  {default, "    script      Manage lua scripts\n"}]}.

--- a/apps/vmq_server/src/vmq_server_cli.erl
+++ b/apps/vmq_server/src/vmq_server_cli.erl
@@ -69,7 +69,7 @@ register_cli() ->
     ok.
 
 register_cli_usage() ->
-    clique:register_usage(["vmq-admin"], usage()),
+    clique:register_usage(["vmq-admin"], fun usage/0),
     clique:register_usage(["vmq-admin", "node"], node_usage()),
     clique:register_usage(["vmq-admin", "node", "start"], start_usage()),
     clique:register_usage(["vmq-admin", "node", "stop"], stop_usage()),
@@ -495,6 +495,7 @@ usage() ->
      "    listener    Manage listener interfaces\n",
      "    metrics     Retrieve System Metrics\n",
      "    api         Manage API keys for the HTTP management interface\n",
+     remove_ok(vmq_plugin_mgr:get_usage_lead_lines()),
      "  Use --help after a sub-command for more details.\n"
     ].
 node_usage() ->
@@ -570,3 +571,6 @@ ensure_all_stopped([App|Apps], Res)  ->
     ensure_all_stopped(Apps -- Stopped, [[App|Stopped]|Res]);
 ensure_all_stopped([], Res) -> Res.
 
+
+remove_ok({ok, Res}) ->
+    Res.

--- a/apps/vmq_webhooks/priv/vmq_webhooks.schema
+++ b/apps/vmq_webhooks/priv/vmq_webhooks.schema
@@ -78,3 +78,8 @@
                    {SortName, maps:update(endpoint, list_to_binary(Endpoint), WH)}
            end, Webhooks)
  end}.
+
+{mapping, "vmq_webhooks.clique_lead_line", "vmq_webhooks.clique_lead_line",
+ [{datatype, string},
+  hidden,
+  {default, "    webhooks    Manage webhooks\n"}]}.


### PR DESCRIPTION
I came up with this way of supporting lead lines for the general `vmq-admin` usage text. Let me know what you think.