### PR TITLE
Remove default bridge configurations

### DIFF
--- a/apps/vmq_bridge/priv/vmq_bridge.schema
+++ b/apps/vmq_bridge/priv/vmq_bridge.schema
@@ -5,13 +5,11 @@
 %% bridges can configured by using different bridge names (e.g. br0). If the 
 %% connection supports SSL encryption bridge.ssl.<name> can be used.
 {mapping, "vmq_bridge.tcp.$name", "vmq_bridge.config", [
-                                                    {default, "127.0.0.1:1889"},
                                                     {datatype, string},
                                                     {include_default, "br0"},
                                                     {commented, "127.0.0.1:1889"}
                                                    ]}. 
 {mapping, "vmq_bridge.ssl.$name", "vmq_bridge.config", [
-                                                    {default, "127.0.0.1:1889"},
                                                     {datatype, string},
                                                     hidden
                                                    ]}. 

--- a/apps/vmq_commons/src/gen_emqtt.erl
+++ b/apps/vmq_commons/src/gen_emqtt.erl
@@ -180,6 +180,7 @@ connecting(connect, State) ->
             active_once(Transport, Sock),
             {next_state, waiting_for_connack, NewState};
         {error, _Reason} ->
+            error_logger:error_msg("connection to ~p:~p failed due to ~p", [Host, Port, _Reason]),
             gen_fsm:send_event_after(3000, connect),
             wrap_res(connecting, on_connect_error, [server_not_found], State)
     end;


### PR DESCRIPTION
The user should define this explicitly.

This makes sure only explicitly defined bridges are activated.