### PR TITLE
Make sure pbkdf2 is included in the release

### DIFF
--- a/apps/vmq_diversity/src/vmq_diversity.app.src
+++ b/apps/vmq_diversity/src/vmq_diversity.app.src
@@ -17,6 +17,7 @@
     epgsql,
     bson,
     mongodb,
+    pbkdf2, %% needed by mongodb but is not declared as a dep there
     eredis,
     hackney,
     jsx,

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Nightly (will become next release)
+
+### vmq_diversity
+
+- Fix mongodb authentication problem due to a missing dependency.
+
 ## VERNEMQ 1.0.0rc2
 
 - Fix wrong lua paths in generated packages.


### PR DESCRIPTION
Fixes #305 

As it wasn't declared as a dependency in the app source file in the
mongodb driver it wasn't included in the release.

Also used the opportunity to switch the mongodb driver to v3.0.1 which
is much more recent.

Removed the erlang-pbkdf2 dependency as it's pulled automatically as a
mongodb dependency.