### PR TITLE
Cleanup vmq admin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,5 +20,6 @@ install: true
 otp_release:
     - 18.3
     - 19.2
+    - 19.3
 before_script: "epmd -daemon"
 script: "./rebar3 as all_tests do eunit, ct"

--- a/apps/vmq_diversity/src/vmq_diversity_cli.erl
+++ b/apps/vmq_diversity/src/vmq_diversity_cli.erl
@@ -40,10 +40,10 @@ register_cli_usage() ->
     clique:register_usage(["vmq-admin", "script", "load"], load_usage()),
     clique:register_usage(["vmq-admin", "script", "reload"], reload_usage()),
     clique:register_usage(["vmq-admin", "script", "unload"], unload_usage()),
-    clique:register_usage(["vmq-admin", "script", "status"], status_usage()).
+    clique:register_usage(["vmq-admin", "script", "show"], show_usage()).
 
 status_cmd() ->
-    Cmd = ["vmq-admin", "script", "status"],
+    Cmd = ["vmq-admin", "script", "show"],
     Callback = fun(_, _, _) ->
                        AllStats = vmq_diversity_script_sup:stats(),
                        lists:foldl(fun({Script, Stats}, Acc) ->
@@ -120,8 +120,8 @@ unload_usage() ->
      "\n\n"
     ].
 
-status_usage() ->
-    ["vmq-admin script status\n\n",
+show_usage() ->
+    ["vmq-admin script show\n\n",
      "  Shows the information of the loaded scripts.",
      "\n\n"
     ].

--- a/apps/vmq_plugin/test/vmq_plugin_SUITE.erl
+++ b/apps/vmq_plugin/test/vmq_plugin_SUITE.erl
@@ -2,7 +2,7 @@
 -include_lib("common_test/include/ct.hrl").
 
 -export([init_per_testcase/2, end_per_testcase/2,
-         init_per_suite/1,
+         init_per_suite/1, end_per_suite/1,
          all/0]).
 
 -export([app_hook_without_proplist/1,
@@ -44,6 +44,9 @@ init_per_testcase(_, Config) ->
 end_per_testcase(_, _Config) ->
     application:stop(vmq_plugin),
     application:unload(vmq_plugin),
+    ok.
+
+end_per_suite(_Config) ->
     ok.
 
 %% Tests

--- a/apps/vmq_server/src/vmq_info_cli.erl
+++ b/apps/vmq_server/src/vmq_info_cli.erl
@@ -20,10 +20,10 @@ register_cli() ->
     vmq_session_list_cmd(),
 
     clique:register_usage(["vmq-admin", "session"], session_usage()),
-    clique:register_usage(["vmq-admin", "session", "list"], vmq_session_list_usage()).
+    clique:register_usage(["vmq-admin", "session", "show"], vmq_session_show_usage()).
 
 vmq_session_list_cmd() ->
-    Cmd = ["vmq-admin", "session", "list"],
+    Cmd = ["vmq-admin", "session", "show"],
     KeySpecs = [],
     ValidInfoItems = vmq_info:session_info_items(),
 
@@ -91,11 +91,11 @@ session_usage() ->
      "  Use --help after a sub-command for more details.\n"
     ].
 
-vmq_session_list_usage() ->
+vmq_session_show_usage() ->
     Options = [io_lib:format("  --~p\n", [Item])
                || Item <- vmq_info:session_info_items()],
     ["vmq-admin session list\n\n",
-     "  Prints some information on running sessions\n\n",
+     "  Show and filter information about MQTT sessions\n\n",
      "Default options:\n"
      "  --client_id --is_online --mountpoint --peer_host --peer_port --user\n\n"
      "Options\n\n"

--- a/apps/vmq_server/src/vmq_server_cli.erl
+++ b/apps/vmq_server/src/vmq_server_cli.erl
@@ -52,7 +52,7 @@ register_cli() ->
     register_cli_usage(),
     vmq_server_start_cmd(),
     vmq_server_stop_cmd(),
-    vmq_server_status_cmd(),
+    vmq_server_show_cmd(),
     vmq_server_metrics_cmd(),
     vmq_server_metrics_reset_cmd(),
     vmq_cluster_join_cmd(),
@@ -81,8 +81,8 @@ register_cli_usage() ->
 
     clique:register_usage(["vmq-admin", "metrics"], metrics_usage()),
 
-    clique:register_usage(["vmq-admin", "api"], api_usage()),
-    clique:register_usage(["vmq-admin", "api", "delete-key"], api_delete_key_usage()),
+    clique:register_usage(["vmq-admin", "api-key"], api_usage()),
+    clique:register_usage(["vmq-admin", "api-key", "delete"], api_delete_key_usage()),
     ok.
 
 vmq_server_stop_cmd() ->
@@ -101,8 +101,8 @@ vmq_server_start_cmd() ->
                end,
     clique:register_command(Cmd, [], [], Callback).
 
-vmq_server_status_cmd() ->
-    Cmd = ["vmq-admin", "cluster", "status"],
+vmq_server_show_cmd() ->
+    Cmd = ["vmq-admin", "cluster", "show"],
     Callback = fun(_, _, _) ->
                        VmqStatus = vmq_cluster:status(),
                        NodeTable =
@@ -355,7 +355,7 @@ vmq_cluster_upgrade_cmd() ->
     clique:register_command(Cmd, KeySpecs, FlagSpecs, Callback).
 
 vmq_mgmt_create_api_key_cmd() ->
-    Cmd = ["vmq-admin", "api", "create-key"],
+    Cmd = ["vmq-admin", "api-key", "create"],
     KeySpecs = [],
     FlagSpecs = [],
     Callback = fun(_, [], []) ->
@@ -365,7 +365,7 @@ vmq_mgmt_create_api_key_cmd() ->
     clique:register_command(Cmd, KeySpecs, FlagSpecs, Callback).
 
 vmq_mgmt_delete_api_key_cmd() ->
-    Cmd = ["vmq-admin", "api", "delete-key"],
+    Cmd = ["vmq-admin", "api-key", "delete"],
     KeySpecs = [{'key', [{typecast, fun(Key) ->
                                             list_to_binary(Key)
                                     end}]}],
@@ -377,7 +377,7 @@ vmq_mgmt_delete_api_key_cmd() ->
     clique:register_command(Cmd, KeySpecs, FlagSpecs, Callback).
 
 vmq_mgmt_list_api_keys_cmd() ->
-    Cmd = ["vmq-admin", "api", "list-keys"],
+    Cmd = ["vmq-admin", "api-key", "show"],
     KeySpecs = [],
     FlagSpecs = [],
     Callback = fun(_, _, _) ->
@@ -458,7 +458,7 @@ usage() ->
      "    plugin      Manage plugin system\n",
      "    listener    Manage listener interfaces\n",
      "    metrics     Retrieve System Metrics\n",
-     "    api         Manage API keys for the HTTP management interface\n",
+     "    api-key     Manage API keys for the HTTP management interface\n",
      remove_ok(vmq_plugin_mgr:get_usage_lead_lines()),
      "  Use --help after a sub-command for more details.\n"
     ].
@@ -475,7 +475,7 @@ cluster_usage() ->
     ["vmq-admin cluster <sub-command>\n\n",
      "  Administrate cluster membership for this particular VerneMQ node.\n\n",
      "  Sub-commands:\n",
-     "    status      Prints cluster status information\n",
+     "    show        Prints cluster information\n",
      "    join        Join a cluster\n",
      "    leave       Leave the cluster\n\n",
      "  Use --help after a sub-command for more details.\n"
@@ -490,16 +490,16 @@ metrics_usage() ->
     ].
 
 api_usage() ->
-    ["vmq-admin api <sub-command>\n\n",
+    ["vmq-admin api-key <sub-command>\n\n",
      "  Create, delete, and show API keys for the HTTP management interface.\n\n",
      "  Sub-commands:\n",
-     "    create-key  Creates a new API key.\n",
-     "    delete-key  Deletes an existing API key.\n",
-     "    list-keys   Shows all API keys.\n"
+     "    create      Creates a new API key.\n",
+     "    delete      Deletes an existing API key.\n",
+     "    show        Shows all API keys.\n"
     ].
 
 api_delete_key_usage() ->
-    ["vmq-admin api delete-key key=<API Key>\n\n",
+    ["vmq-admin api-key delete key=<API Key>\n\n",
      "  Deletes an existing API Key.\n\n"
     ].
 

--- a/apps/vmq_webhooks/src/vmq_webhooks_cli.erl
+++ b/apps/vmq_webhooks/src/vmq_webhooks_cli.erl
@@ -24,7 +24,7 @@ register_cli() ->
     deregister_cmd().
 
 cache_stats_cmd() ->
-    Cmd = ["vmq-admin", "webhooks", "cache", "stats"],
+    Cmd = ["vmq-admin", "webhooks", "cache", "show"],
     FlagSpecs = [{reset, [{longname, "reset"}]}],
     Callback =
         fun(_, [], []) ->
@@ -49,7 +49,7 @@ cache_stats_cmd() ->
     clique:register_command(Cmd, [], FlagSpecs, Callback).
 
 status_cmd() ->
-    Cmd = ["vmq-admin", "webhooks", "status"],
+    Cmd = ["vmq-admin", "webhooks", "show"],
     Callback =
         fun(_, [], []) ->
                 Table = 
@@ -163,14 +163,14 @@ register_cli_usage() ->
     clique:register_usage(["vmq-admin", "webhooks"], webhooks_usage()),
     clique:register_usage(["vmq-admin", "webhooks", "register"], register_usage()),
     clique:register_usage(["vmq-admin", "webhooks", "deregister"], deregister_usage()),
-    clique:register_usage(["vmq-admin", "webhooks", "status"], status_usage()),
+    clique:register_usage(["vmq-admin", "webhooks", "show"], show_usage()),
     clique:register_usage(["vmq-admin", "webhooks", "cache"], cache_usage()).
 
 webhooks_usage() ->
     ["vmq-admin webhooks <sub-command>\n\n",
      "  Manage VerneMQ Webhooks.\n\n",
      "  Sub-commands:\n",
-     "    status      Show the status of registered webhooks\n",
+     "    show        Show all registered webhooks\n",
      "    register    Register a webhook\n",
      "    deregister  Deregister a webhook\n",
      "    cache       Manage the webhooks cache\n\n",
@@ -192,8 +192,8 @@ deregister_usage() ->
      "\n\n"
     ].
 
-status_usage() ->
-    ["vmq-admin webhooks status\n\n",
+show_usage() ->
+    ["vmq-admin webhooks show\n\n",
      "  Shows the information of the registered webhooks.",
      "\n\n"
     ].
@@ -203,5 +203,5 @@ cache_usage() ->
      "  Manage the webhooks cache."
      "\n\n",
      "  Sub-commands:\n",
-     "    stats       Show statistics about the cache\n"
+     "    show       Show statistics about the cache\n"
     ].

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,18 @@
 
 ## Nightly (will become next release)
 
+- To make the `vmq-admin` tool more consistent, the following changes have been
+  made:
+  
+  vmq-admin script status -> vmq-admin script show
+  vmq-admin session list -> vmq-admin session show
+  vmq-admin cluster status -> vmq-admin cluster show
+  vmq-admin webhooks status -> vmq-admin webhooks show
+  vmq-admin webhooks cache stats -> vmq-admin webhooks cache show
+  vmq-admin api create-key -> vmq-admin api-key create
+  vmq-admin api delete-key -> vmq-admin api-key delete
+  vmq-admin api list-keys -> vmq-admin api-key show
+
 ### vmq_diversity
 
 - Fix mongodb authentication problem due to a missing dependency.


### PR DESCRIPTION
Attempt at cleaning up the `vmq-admin` cli interface (Fixes #310).

Comments @dergraf @ioolkos ?

Note: if we merge this we need to make sure our docs are fixed up as well.

Note2: I also added a small fix to one of the common tests to make it Erlang 19.3 compatible and took the opportunity to add 19.3 as a travis target.

/cc @kellycampbell