### PR TITLE
Fix list session bug

### DIFF
--- a/apps/vmq_ql/src/vmq_ql_query_mgr.erl
+++ b/apps/vmq_ql/src/vmq_ql_query_mgr.erl
@@ -213,14 +213,6 @@ fetch_results(Limit, #state{idx=Idx, result=ResultTab, ready=Ready} = State) ->
                 fun({RowKey, Row}, AccAccIdx) ->
                         ets:insert(ResultTab, {{RowKey, AccAccIdx}, Row}),
                         AccAccIdx + 1
-                end, AccIdx, safe_fetch(Pid, desc, Limit))
+                end, AccIdx, vmq_ql_query:fetch(Pid, desc, Limit))
       end, Idx, Ready),
     State#state{idx=NewIdx}.
-
-safe_fetch(Pid, Order, Limit) ->
-    case is_process_alive(Pid) of
-        true ->
-            vmq_ql_query:fetch(Pid, Order, Limit);
-        false ->
-            []
-    end.


### PR DESCRIPTION
The `is_process_alive/1` function is only allowed on local pids. Since
the `vmq_ql_query:fetch/3` already returns `[]` in the case that the
`Pid` doesn't exist we can remove the `safe_fetch/3` and the check it
performs entirely.

Fixes #316 