### PR TITLE
Upgrade bcrypt

### DIFF
--- a/apps/vmq_diversity/rebar.config
+++ b/apps/vmq_diversity/rebar.config
@@ -9,8 +9,8 @@
         {eredis, "1.0.8"},
         {hackney, "1.6.0"},
         {jsx, "2.8.0"},
-        {bcrypt, "0.5.0-p3a"},
 
+        {bcrypt, {git, "git://github.com/smarkets/erlang-bcrypt.git", {branch, "master"}}},
         {vernemq_dev, {git, "git://github.com/erlio/vernemq_dev.git", {branch, "master"}}},
         {gen_server2, {git, "git://github.com/erlio/gen_server2.git", {branch, "master"}}},
         {luerl, {git, "git://github.com/rvirding/luerl.git", {branch, "develop"}}},

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,5 +1,8 @@
 {"1.1.0",
-[{<<"bcrypt">>,{pkg,<<"bcrypt">>,<<"0.5.0-p3a">>},0},
+[{<<"bcrypt">>,
+  {git,"git://github.com/smarkets/erlang-bcrypt.git",
+       {ref,"a63df34d4957dbb70a703c67c75ed9fee2c78971"}},
+  0},
  {<<"bson">>,
   {git,"git://github.com/vintenove/bson-erlang",
        {ref,"01bd54a53112e5f2615f7ecb382f0cbf148bb7ce"}},
@@ -110,7 +113,6 @@
   0}]}.
 [
 {pkg_hash,[
- {<<"bcrypt">>, <<"A9D4D17749F5FF565F277960A068388EDB563B8FBA3BE901B9B4E0DE19848735">>},
  {<<"certifi">>, <<"A7966EFB868B179023618D29A407548F70C52466BF1849B9E8EBD0E34B7EA11F">>},
  {<<"cowboy">>, <<"A324A8DF9F2316C833A470D918AAF73AE894278B8AA6226CE7A9BF699388F878">>},
  {<<"cowlib">>, <<"9D769A1D062C9C3AC753096F868CA121E2730B9A377DE23DEC0F7E08B1DF84EE">>},


### PR DESCRIPTION
This version fixes build errors on Alpine Linux (by including
`sys/types.h`), a memory leak in the salt generation function nif, but
is otherwise the same as the one we used to use.