### PR TITLE
Handle subscriber id modifier

### DIFF
--- a/apps/vmq_diversity/src/vmq_diversity_cache.erl
+++ b/apps/vmq_diversity/src/vmq_diversity_cache.erl
@@ -313,12 +313,12 @@ validate_modifiers(Type, Modifiers) ->
     Ret =
     case Type of
         publish ->
-            vmq_diversity_plugin:check_modifiers(auth_on_publish, NewModifiers);
+            vmq_plugin_util:check_modifiers(auth_on_publish, NewModifiers);
         subscribe ->
             %% massage the modifiers to take the same form as it were returned by
             %% the callback directly
             %% in Lua: { {topic, qos}, ... }
-            vmq_diversity_plugin:check_modifiers(auth_on_subscribe, NewModifiers)
+            vmq_plugin_util:check_modifiers(auth_on_subscribe, NewModifiers)
     end,
     case Ret of
         error ->

--- a/apps/vmq_diversity/src/vmq_diversity_plugin.erl
+++ b/apps/vmq_diversity/src/vmq_diversity_plugin.erl
@@ -47,9 +47,6 @@
          register_hook/1
         ]).
 
-%% used by vmq_diversity_cache
--export([check_modifiers/2]).
-
 %% gen_server callbacks
 -export([init/1,
          handle_call/3,
@@ -385,7 +382,7 @@ all_till_ok([Pid|Rest], HookName, Args) ->
         true ->
             ok;
         Modifiers when is_list(Modifiers) ->
-            case check_modifiers(HookName, Modifiers) of
+            case vmq_plugin_util:check_modifiers(HookName, Modifiers) of
                 error -> error;
                 CheckedModifiers ->
                     {ok, CheckedModifiers}
@@ -414,126 +411,6 @@ all([], _, _) -> next.
 
 unword(T) ->
     iolist_to_binary(vmq_topic:unword(T)).
-
-%% Validators For the Modifiers
-val_bool(B) -> is_boolean(B).
-
-val_atom(B) when is_binary(B) -> {ok, binary_to_existing_atom(B, utf8)};
-val_atom(_) -> false.
-
-val_binary(B) -> is_binary(B).
-
-val_string(B) when is_binary(B) -> {ok, binary_to_list(B)};
-val_string(_) -> false.
-
-val_qos(N) when is_number(N)
-                and (N >= 0) and (N =< 2) -> {ok, round(N)};
-val_qos(_) -> false.
-
-val_int(I) when is_integer(I) -> true;
-val_int(N) when is_number(N) -> {ok, round(N)};
-val_int(_) -> false.
-
-val_subscriber_id([{_, _}|_] = SubscriberIdModifier) ->
-    case {lists:keyfind(client_id, 1, SubscriberIdModifier),
-          lists:keyfind(mountpoint, 1, SubscriberIdModifier)} of
-        {{_, ClientId}, {_, Mountpoint}} when is_binary(ClientId) and is_binary(Mountpoint) ->
-            {ok, {binary_to_list(Mountpoint), ClientId}};
-        _ ->
-            false
-    end;
-val_subscriber_id(_) -> false.
-
-val_pub_topic(B) when is_binary(B) ->
-    case vmq_topic:validate_topic(publish, B) of
-        {ok, T} -> {ok, T};
-        _ -> false
-    end;
-val_pub_topic(_) -> false.
-
-modifiers(auth_on_register) ->
-    [{allow_register, fun val_bool/1},
-     {allow_publish, fun val_bool/1},
-     {allow_subscribe, fun val_bool/1},
-     {allow_unsubscribe, fun val_bool/1},
-     {max_message_size, fun val_int/1},
-     {subscriber_id, fun val_subscriber_id/1},
-     {clean_session, fun val_bool/1},
-     {max_message_rate, fun val_int/1},
-     {max_inflight_messages, fun val_int/1},
-     {shared_subscription_policy, fun val_atom/1},
-     {retry_interval, fun val_int/1},
-     {upgrade_qos, fun val_bool/1},
-     {allow_multiple_sessions, fun val_bool/1},
-     {max_online_messages, fun val_int/1},
-     {max_offline_messages, fun val_int/1},
-     {queue_deliver_mode, fun val_atom/1},
-     {queue_type, fun val_atom/1},
-     {max_drain_time, fun val_int/1},
-     {max_msgs_per_drain_step, fun val_int/1}];
-modifiers(auth_on_publish) ->
-    [{topic, fun val_pub_topic/1},
-     {payload, fun val_binary/1},
-     {qos, fun val_qos/1},
-     {retain, fun val_bool/1},
-     {mountpoint, fun val_string/1}];
-modifiers(on_deliver) ->
-    [{topic, fun val_pub_topic/1},
-     {payload, fun val_binary/1}];
-modifiers(_) -> [].
-
-check_modifiers(auth_on_subscribe, Modifiers) ->
-    %% auth_on_subscribe take a special form
-    lists:foldl(fun (_, error) -> error;
-                    ([T, Q], Acc) when is_binary(T) and is_number(Q) ->
-                        case vmq_topic:validate_topic(subscribe, T) of
-                            {ok, Topic} ->
-                                [{Topic, round(Q)}|Acc];
-                            {error, Reason} ->
-                                lager:error("can't parse topic ~p in auth_on_subscribe", [{T, Q}, Reason]),
-                                error
-                        end;
-                   (T, _) ->
-                        lager:error("can't rewrite topic in auth_on_subscribe due to wrong format ~p", [T]),
-                        error
-                end, [], Modifiers);
-check_modifiers(on_unsubscribe, Modifiers) ->
-    %% on_unsubscribe take a special form
-    lists:foldl(fun (_, error) -> error;
-                    (T, Acc) when is_binary(T) ->
-                        case vmq_topic:validate_topic(subscribe, T) of
-                            {ok, Topic} ->
-                                [Topic|Acc];
-                            {error, Reason} ->
-                                lager:error("can't parse topic ~p in on_unsubscribe", [T, Reason]),
-                                error
-                        end;
-                   (T, _) ->
-                        lager:error("can't rewrite topic in on_unsubscribe due to wrong format ~p", [T]),
-                        error
-                end, [], Modifiers);
-check_modifiers(Hook, [{_,_}|_] = Modifiers) ->
-    AllowedModifiers = modifiers(Hook),
-    lists:foldl(fun (_, error) -> error;
-                    ({ModKey, ModVal}, Acc) ->
-                        case lists:keyfind(ModKey, 1, AllowedModifiers) of
-                            false ->
-                                error;
-                            {_, ValidatorFun} ->
-                                case ValidatorFun(ModVal) of
-                                    true ->
-                                        [{ModKey, ModVal}|Acc];
-                                    false ->
-                                        lager:error("can't validate modifier ~p ~p ~p", [Hook, ModKey, ModVal]),
-                                        error;
-                                    {ok, NewModVal} ->
-                                        [{ModKey, NewModVal}|Acc]
-                                end
-                        end
-                end, [], Modifiers);
-check_modifiers(Hook, Modifiers) ->
-    lager:error("can't check modifiers ~p for hook ~p", [Hook, Modifiers]),
-    error.
 
 peer({Peer, Port}) when is_tuple(Peer) and is_integer(Port) ->
     case inet:ntoa(Peer) of

--- a/apps/vmq_plugin/src/vmq_plugin_util.erl
+++ b/apps/vmq_plugin/src/vmq_plugin_util.erl
@@ -1,0 +1,142 @@
+%% Copyright 2017 Erlio GmbH Basel Switzerland (http://erl.io)
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+-module(vmq_plugin_util).
+
+-export([check_modifiers/2]).
+
+check_modifiers(auth_on_subscribe, Modifiers) ->
+    %% auth_on_subscribe take a special form
+    lists:foldl(fun (_, error) -> error;
+                    ([T, Q], Acc) when is_binary(T) and is_number(Q) ->
+                        case vmq_topic:validate_topic(subscribe, T) of
+                            {ok, Topic} ->
+                                [{Topic, to_internal_qos(round(Q))}|Acc];
+                            {error, Reason} ->
+                                lager:error("can't parse topic ~p in auth_on_subscribe", [{T, Q}, Reason]),
+                                error
+                        end;
+                   (T, _) ->
+                        lager:error("can't rewrite topic in auth_on_subscribe due to wrong format ~p", [T]),
+                        error
+                end, [], Modifiers);
+check_modifiers(on_unsubscribe, Modifiers) ->
+    %% on_unsubscribe take a special form
+    lists:foldl(fun (_, error) -> error;
+                    (T, Acc) when is_binary(T) ->
+                        case vmq_topic:validate_topic(subscribe, T) of
+                            {ok, Topic} ->
+                                [Topic|Acc];
+                            {error, Reason} ->
+                                lager:error("can't parse topic ~p in on_unsubscribe", [T, Reason]),
+                                error
+                        end;
+                   (T, _) ->
+                        lager:error("can't rewrite topic in on_unsubscribe due to wrong format ~p", [T]),
+                        error
+                end, [], Modifiers);
+check_modifiers(Hook, [{_,_}|_] = Modifiers) ->
+    AllowedModifiers = modifiers(Hook),
+    lists:foldl(fun (_, error) -> error;
+                    ({ModKey, ModVal}, Acc) ->
+                        case lists:keyfind(ModKey, 1, AllowedModifiers) of
+                            false ->
+                                error;
+                            {_, ValidatorFun} ->
+                                case ValidatorFun(ModVal) of
+                                    true ->
+                                        [{ModKey, ModVal}|Acc];
+                                    false ->
+                                        lager:error("can't validate modifier ~p ~p ~p", [Hook, ModKey, ModVal]),
+                                        error;
+                                    {ok, NewModVal} ->
+                                        [{ModKey, NewModVal}|Acc]
+                                end
+                        end
+                end, [], Modifiers);
+check_modifiers(Hook, Modifiers) ->
+    lager:error("can't check modifiers ~p for hook ~p", [Hook, Modifiers]),
+    error.
+
+to_internal_qos(128) ->
+    not_allowed;
+to_internal_qos(V) when is_integer(V) ->
+    V.
+
+modifiers(auth_on_register) ->
+    [{allow_register, fun val_bool/1},
+     {allow_publish, fun val_bool/1},
+     {allow_subscribe, fun val_bool/1},
+     {allow_unsubscribe, fun val_bool/1},
+     {max_message_size, fun val_int/1},
+     {subscriber_id, fun val_subscriber_id/1},
+     {clean_session, fun val_bool/1},
+     {max_message_rate, fun val_int/1},
+     {max_inflight_messages, fun val_int/1},
+     {shared_subscription_policy, fun val_atom/1},
+     {retry_interval, fun val_int/1},
+     {upgrade_qos, fun val_bool/1},
+     {allow_multiple_sessions, fun val_bool/1},
+     {max_online_messages, fun val_int/1},
+     {max_offline_messages, fun val_int/1},
+     {queue_deliver_mode, fun val_atom/1},
+     {queue_type, fun val_atom/1},
+     {max_drain_time, fun val_int/1},
+     {max_msgs_per_drain_step, fun val_int/1}];
+modifiers(auth_on_publish) ->
+    [{topic, fun val_pub_topic/1},
+     {payload, fun val_binary/1},
+     {qos, fun val_qos/1},
+     {retain, fun val_bool/1},
+     {mountpoint, fun val_string/1}];
+modifiers(on_deliver) ->
+    [{topic, fun val_pub_topic/1},
+     {payload, fun val_binary/1}];
+modifiers(_) -> [].
+
+%% Validators For the Modifiers
+
+val_bool(B) -> is_boolean(B).
+
+val_atom(B) when is_binary(B) -> {ok, binary_to_existing_atom(B, utf8)};
+val_atom(_) -> false.
+
+val_binary(B) -> is_binary(B).
+
+val_string(B) when is_binary(B) -> {ok, binary_to_list(B)};
+val_string(_) -> false.
+
+val_qos(N) when is_number(N)
+                and (N >= 0) and (N =< 2) -> {ok, round(N)};
+val_qos(_) -> false.
+
+val_int(I) when is_integer(I) -> true;
+val_int(N) when is_number(N) -> {ok, round(N)};
+val_int(_) -> false.
+
+val_subscriber_id([{_, _}|_] = SubscriberIdModifier) ->
+    case {lists:keyfind(client_id, 1, SubscriberIdModifier),
+          lists:keyfind(mountpoint, 1, SubscriberIdModifier)} of
+        {{_, ClientId}, {_, Mountpoint}} when is_binary(ClientId) and is_binary(Mountpoint) ->
+            {ok, {binary_to_list(Mountpoint), ClientId}};
+        _ ->
+            false
+    end;
+val_subscriber_id(_) -> false.
+
+val_pub_topic(B) when is_binary(B) ->
+    case vmq_topic:validate_topic(publish, B) of
+        {ok, T} -> {ok, T};
+        _ -> false
+    end;
+val_pub_topic(_) -> false.

--- a/apps/vmq_webhooks/test/vmq_webhooks_SUITE.erl
+++ b/apps/vmq_webhooks/test/vmq_webhooks_SUITE.erl
@@ -87,15 +87,15 @@ cache_expired_entry(_) ->
     Endpoint = ?ENDPOINT ++ "/cache1s",
     Self = pid_to_bin(self()),
     register_hook(auth_on_register, Endpoint),
-    {ok, []} = vmq_plugin:all_till_ok(auth_on_register,
+    ok = vmq_plugin:all_till_ok(auth_on_register,
                                       [?PEER, {?MOUNTPOINT, ?ALLOWED_CLIENT_ID}, Self, ?PASSWORD, true]),
     exp_response(cache_auth_on_register_ok),
     %% wait until the entry was expired
     timer:sleep(1100),
-    {ok ,[]} = vmq_plugin:all_till_ok(auth_on_register,
+    ok = vmq_plugin:all_till_ok(auth_on_register,
                                       [?PEER, {?MOUNTPOINT, ?ALLOWED_CLIENT_ID}, Self, ?PASSWORD, true]),
     exp_response(cache_auth_on_register_ok),
-    {ok ,[]} = vmq_plugin:all_till_ok(auth_on_register,
+    ok = vmq_plugin:all_till_ok(auth_on_register,
                                       [?PEER, {?MOUNTPOINT, ?ALLOWED_CLIENT_ID}, Self, ?PASSWORD, true]),
     exp_response(cache_auth_on_register_ok),
     ok = exp_nothing(200),
@@ -111,10 +111,10 @@ cache_auth_on_register(_) ->
     Endpoint = ?ENDPOINT ++ "/cache",
     Self = pid_to_bin(self()),
     register_hook(auth_on_register, Endpoint),
-    {ok, []} = vmq_plugin:all_till_ok(auth_on_register,
+    ok = vmq_plugin:all_till_ok(auth_on_register,
                                       [?PEER, {?MOUNTPOINT, ?ALLOWED_CLIENT_ID}, Self, ?PASSWORD, true]),
     exp_response(cache_auth_on_register_ok),
-    {ok ,[]} = vmq_plugin:all_till_ok(auth_on_register,
+    ok = vmq_plugin:all_till_ok(auth_on_register,
                                       [?PEER, {?MOUNTPOINT, ?ALLOWED_CLIENT_ID}, Self, ?PASSWORD, true]),
     ok = exp_nothing(200),
     #{{entries,<<"http://localhost:34567/cache">>,
@@ -129,10 +129,10 @@ cache_auth_on_publish(_) ->
     Endpoint = ?ENDPOINT ++ "/cache",
     Self = pid_to_bin(self()),
     register_hook(auth_on_publish, Endpoint),
-    {ok, []} = vmq_plugin:all_till_ok(auth_on_publish,
+    ok = vmq_plugin:all_till_ok(auth_on_publish,
                       [Self, {?MOUNTPOINT, ?ALLOWED_CLIENT_ID}, 1, ?TOPIC, ?PAYLOAD, false]),
     exp_response(cache_auth_on_publish_ok),
-    {ok, []} = vmq_plugin:all_till_ok(auth_on_publish,
+    ok = vmq_plugin:all_till_ok(auth_on_publish,
                       [Self, {?MOUNTPOINT, ?ALLOWED_CLIENT_ID}, 1, ?TOPIC, ?PAYLOAD, false]),
     ok = exp_nothing(200),
     #{{entries,<<"http://localhost:34567/cache">>,
@@ -147,10 +147,10 @@ cache_auth_on_subscribe(_) ->
     Endpoint = ?ENDPOINT ++ "/cache",
     Self = pid_to_bin(self()),
     register_hook(auth_on_subscribe, Endpoint),
-    {ok, []} = vmq_plugin:all_till_ok(auth_on_subscribe,
+    ok = vmq_plugin:all_till_ok(auth_on_subscribe,
                       [Self, {?MOUNTPOINT, ?ALLOWED_CLIENT_ID}, [{?TOPIC, 1}]]),
     exp_response(cache_auth_on_subscribe_ok),
-    {ok, []} = vmq_plugin:all_till_ok(auth_on_subscribe,
+    ok = vmq_plugin:all_till_ok(auth_on_subscribe,
                       [Self, {?MOUNTPOINT, ?ALLOWED_CLIENT_ID}, [{?TOPIC, 1}]]),
     ok = exp_nothing(200),
     #{{entries,<<"http://localhost:34567/cache">>,
@@ -163,20 +163,20 @@ cache_auth_on_subscribe(_) ->
 
 auth_on_register_test(_) ->
     register_hook(auth_on_register, ?ENDPOINT),
-    {ok, []} = vmq_plugin:all_till_ok(auth_on_register,
+    ok = vmq_plugin:all_till_ok(auth_on_register,
                       [?PEER, {?MOUNTPOINT, ?ALLOWED_CLIENT_ID}, ?USERNAME, ?PASSWORD, true]),
     {error, error} = vmq_plugin:all_till_ok(auth_on_register,
                       [?PEER, {?MOUNTPOINT, ?NOT_ALLOWED_CLIENT_ID}, ?USERNAME, ?PASSWORD, true]),
     {error, chain_exhausted} = vmq_plugin:all_till_ok(auth_on_register,
                       [?PEER, {?MOUNTPOINT, ?IGNORED_CLIENT_ID}, ?USERNAME, ?PASSWORD, true]),
-    {ok, [{client_id, <<"changed_client_id">>},
-          {mountpoint, "mynewmount"}]} = vmq_plugin:all_till_ok(auth_on_register,
+    {ok, [{subscriber_id,
+           {"mynewmount", <<"changed_client_id">>}}]} = vmq_plugin:all_till_ok(auth_on_register,
                       [?PEER, {?MOUNTPOINT, ?CHANGED_CLIENT_ID}, ?USERNAME, ?PASSWORD, true]),
     deregister_hook(auth_on_register, ?ENDPOINT).
 
 auth_on_publish_test(_) ->
     register_hook(auth_on_publish, ?ENDPOINT),
-    {ok, []} = vmq_plugin:all_till_ok(auth_on_publish,
+    ok = vmq_plugin:all_till_ok(auth_on_publish,
                       [?USERNAME, {?MOUNTPOINT, ?ALLOWED_CLIENT_ID}, 1, ?TOPIC, ?PAYLOAD, false]),
     {error, error} = vmq_plugin:all_till_ok(auth_on_publish,
                       [?USERNAME, {?MOUNTPOINT, ?NOT_ALLOWED_CLIENT_ID}, 1, ?TOPIC, ?PAYLOAD, false]),
@@ -188,7 +188,7 @@ auth_on_publish_test(_) ->
 
 auth_on_subscribe_test(_) ->
     register_hook(auth_on_subscribe, ?ENDPOINT),
-    {ok, []} = vmq_plugin:all_till_ok(auth_on_subscribe,
+    ok = vmq_plugin:all_till_ok(auth_on_subscribe,
                       [?USERNAME, {?MOUNTPOINT, ?ALLOWED_CLIENT_ID}, [{?TOPIC, 1}]]),
     {error, error} = vmq_plugin:all_till_ok(auth_on_subscribe,
                       [?USERNAME, {?MOUNTPOINT, ?NOT_ALLOWED_CLIENT_ID}, [{?TOPIC, 1}]]),
@@ -226,7 +226,7 @@ on_subscribe_test(_) ->
 
 on_unsubscribe_test(_) ->
     register_hook(on_unsubscribe, ?ENDPOINT),
-    {ok, []} = vmq_plugin:all_till_ok(on_unsubscribe,
+    ok = vmq_plugin:all_till_ok(on_unsubscribe,
                                 [?USERNAME, {?MOUNTPOINT, ?ALLOWED_CLIENT_ID}, [?TOPIC]]),
     {ok, [[<<"rewritten">>, <<"topic">>]]} = vmq_plugin:all_till_ok(on_unsubscribe,
                       [?USERNAME, {?MOUNTPOINT, ?CHANGED_CLIENT_ID}, [?TOPIC]]),
@@ -235,7 +235,7 @@ on_unsubscribe_test(_) ->
 on_deliver_test(_) ->
     register_hook(on_deliver, ?ENDPOINT),
     Self = pid_to_bin(self()),
-    {ok, []} = vmq_plugin:all_till_ok(on_deliver,
+    ok = vmq_plugin:all_till_ok(on_deliver,
                                 [Self, {?MOUNTPOINT, ?ALLOWED_CLIENT_ID}, ?TOPIC, ?PAYLOAD]),
     ok = exp_response(on_deliver_ok),
     deregister_hook(on_deliver, ?ENDPOINT).
@@ -281,7 +281,7 @@ auth_on_register_undefined_creds_test(_) ->
     register_hook(auth_on_register, ?ENDPOINT),
     Username = undefined,
     Password = undefined,
-    {ok, []} = vmq_plugin:all_till_ok(auth_on_register,
+    ok = vmq_plugin:all_till_ok(auth_on_register,
                       [?PEER, {?MOUNTPOINT, <<"undefined_creds">>}, Username, Password, true]),
     deregister_hook(auth_on_register, ?ENDPOINT).
     

--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,8 @@
 ## Nightly
 
 - Fix formatting bug in the 'vmq-admin trace` command.
+- Handle empty modifier list correctly in `vmq_webhooks` (#339).
+- Handle client_id and mountpoint modifiers correctly in `vmq_webhooks` (#332).
 
 ## VERNEMQ 1.0.0
 


### PR DESCRIPTION
This moves the `check_modifier/1` into `vmq_plugin` so it can be reused from `vmq_diversity` and `vmq_wehbooks`.

This solves both #339 and #332 

This PR replaces #343 
