### PR TITLE
Purge stale subscriber data when (re)starting VerneMQ

### DIFF
--- a/apps/vmq_server/src/vmq_reg.erl
+++ b/apps/vmq_server/src/vmq_reg.erl
@@ -38,7 +38,6 @@
 
          migrate_offline_queues/1,
          fix_dead_queues/2
-
         ]).
 
 %% called by vmq_cluster_com
@@ -711,3 +710,4 @@ status(SubscriberId) ->
         QPid ->
             {ok, vmq_queue:status(QPid)}
     end.
+

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,8 @@
 
 ## Nightly
 
+- Purge node-local clean session true subscriber data when restarting
+  VerneMQ as these would otherwise erroneously still exist.
 - The metrics reporting sizes of retained messages `gauge.retain_memory` and
   routes `gauge.router_memory` were incorrectly done in system word sizes
   instead of in bytes. This has been corrected. Further the
@@ -12,7 +14,7 @@
 - Fix bug occurring when publishing across nodes where more than one subscriber
   are on one node and the publisher on another. In this case only one of the
   subscribers would receive the message.
-- Fix formatting bug in the 'vmq-admin trace` command.
+- Fix formatting bug in the `vmq-admin trace` command.
 - Handle empty modifier list correctly in `vmq_webhooks` (#339).
 - Handle client_id and mountpoint modifiers correctly in `vmq_webhooks` (#332).
 


### PR DESCRIPTION
When a VerneMQ node is stopped, the clean session true session data
which is persisted to disk will not neccesarily be deleted and will
still be there when VerneMQ starts.

This commit will make sure to delete all node-local subscriptions which
are made by a clean session true subscriber when starting VerneMQ.