### PR TITLE
Avoid multiple hook registrations upon `script reload`

### DIFF
--- a/apps/vmq_diversity/src/vmq_diversity_plugin.erl
+++ b/apps/vmq_diversity/src/vmq_diversity_plugin.erl
@@ -116,7 +116,12 @@ handle_call({register_hook, OwnerPid, Hook}, _From, State) ->
             enable_hook(HookName),
             ets:insert(?TBL, {HookName, [OwnerPid]});
         [{_, ScriptOwners}] ->
-            ets:insert(?TBL, {HookName, [OwnerPid|ScriptOwners]})
+            case lists:member(OwnerPid, ScriptOwners) of
+                true ->
+                    ok;
+                false ->
+                    ets:insert(?TBL, {HookName, [OwnerPid|ScriptOwners]})
+            end
     end,
     monitor(process, OwnerPid),
     Reply = ok,

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,8 @@
 
 ## Nightly
 
+- Fix bug causing hooks to be registered multiple times when reloading lua
+  scripts (#348).
 - Fix bug occurring when publishing across nodes where more than one subscriber
   are on one node and the publisher on another. In this case only one of the
   subscribers would receive the message.


### PR DESCRIPTION
Fix for #348 