### PR TITLE
Report ets table metrics in bytes instead of wordsize

### DIFF
--- a/apps/vmq_server/src/vmq_reg_trie.erl
+++ b/apps/vmq_server/src/vmq_reg_trie.erl
@@ -92,7 +92,8 @@ stats() ->
     Mem4 = info(vmq_trie_node, memory),
     Mem5 = info(vmq_trie_remote_subs, memory),
     Memory = Mem1 + Mem2 + Mem3 + Mem4 + Mem5,
-    {NrOfSubs, Memory}.
+    WordSize = erlang:system_info(wordsize),
+    {NrOfSubs, Memory*WordSize}.
 
 info(T, What) ->
     case ets:info(T, What) of

--- a/apps/vmq_server/src/vmq_retain_srv.erl
+++ b/apps/vmq_server/src/vmq_retain_srv.erl
@@ -99,8 +99,13 @@ stats() ->
     case ets:info(?RETAIN_CACHE, size) of
         undefined -> {0, 0};
         V ->
-            M = ets:info(?RETAIN_CACHE, memory)*erlang:system_info(wordsize),
-            {V, M}
+            MC = ets:info(?RETAIN_CACHE, memory),
+            case ets:info(?RETAIN_UPDATE, memory) of
+                undefined ->
+                    {V, MC*erlang:system_info(wordsize)};
+                MU ->
+                    {V, (MC+MU)*erlang:system_info(wordsize)}
+            end
     end.
 
 

--- a/apps/vmq_server/src/vmq_retain_srv.erl
+++ b/apps/vmq_server/src/vmq_retain_srv.erl
@@ -99,7 +99,7 @@ stats() ->
     case ets:info(?RETAIN_CACHE, size) of
         undefined -> {0, 0};
         V ->
-            M = ets:info(?RETAIN_CACHE, memory),
+            M = ets:info(?RETAIN_CACHE, memory)*erlang:system_info(wordsize),
             {V, M}
     end.
 

--- a/changelog.md
+++ b/changelog.md
@@ -2,8 +2,11 @@
 
 ## Nightly
 
-- Fix incorrect metrics reporting ets table sizes. These should be in bytes, but
-  where reported in word-sizes.
+- The metrics reporting sizes of retained messages `gauge.retain_memory` and
+  routes `gauge.router_memory` were incorrectly done in system word sizes
+  instead of in bytes. This has been corrected. Further the
+  `gauge.retain_memory` metric now also includes temporary storage used before
+  persisting messages to disk.
 - Fix bug causing hooks to be registered multiple times when reloading lua
   scripts (#348).
 - Fix bug occurring when publishing across nodes where more than one subscriber

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,8 @@
 
 ## Nightly
 
+- Fix incorrect metrics reporting ets table sizes. These should be in bytes, but
+  where reported in word-sizes.
 - Fix bug causing hooks to be registered multiple times when reloading lua
   scripts (#348).
 - Fix bug occurring when publishing across nodes where more than one subscriber


### PR DESCRIPTION
To me it's a bug that we report the sizes of ets tables (retained and subscription data) in wordsizes which vary depending on the platform (4bytes on 32bit and 8 bytes on 64 bit platforms), so I changed these metrics so they're reported in bytes instead.