### PR TITLE
Add eldap as a release dependency

### DIFF
--- a/apps/vmq_diversity/src/vmq_diversity.app.src
+++ b/apps/vmq_diversity/src/vmq_diversity.app.src
@@ -9,6 +9,7 @@
     crypto,
     public_key,
     ssl,
+    eldap,
     lager,
     clique,
     poolboy,


### PR DESCRIPTION
This would enable us and customers to build plugins using the `eldap` application.