### PR TITLE
Forward connections without username/password to next hook in chain

### DIFF
--- a/apps/vmq_passwd/src/vmq_passwd.erl
+++ b/apps/vmq_passwd/src/vmq_passwd.erl
@@ -99,9 +99,9 @@ load_from_list(List) ->
     del_aged_entries().
 
 check(undefined, _) ->
-    {error, not_authorized};
+    next;
 check(_, undefined) ->
-    {error, invalid_credentials};
+    next;
 check(User, Password) ->
     case ets:lookup(?TABLE, ensure_binary(User)) of
         [{_, SaltB64, EncPassword, _}] ->

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@
 - Add more detail to the client expiration log message.
 - Safeguard Lua function calls
 - Fix bug where websocket connections were incorrectly terminated (#387).
+- Fix breakage of event hook chain in `vmq_passwd` (#396).
 
 ## VERNEMQ 1.0.1
 


### PR DESCRIPTION
`vmq_passwd` rejected connections without username/password with `error` which prevents further handling in later hooks in chain. This is now changed to forward the event to next hook by returning `next` for connections without username/password.

This should fix erlio/vernemq#396.