### PR TITLE
Add info log to show that cluster connectivity has been restored

### DIFF
--- a/apps/vmq_server/src/vmq_cluster_node.erl
+++ b/apps/vmq_server/src/vmq_cluster_node.erl
@@ -204,6 +204,7 @@ connect(#state{node=RemoteNode} = State) ->
                     Msg = [<<"vmq-connect">>, <<L:32, NodeName/binary>>],
                     case send(Transport, Socket, Msg) of
                         ok ->
+                            lager:info("successfully connected to cluster node ~p", [RemoteNode]),
                             State#state{socket=Socket, transport=Transport,
                                         %% !!! remote node is reachable
                                         reachable=true};

--- a/changelog.md
+++ b/changelog.md
@@ -1,12 +1,12 @@
 # Changelog
 
-=======
-
-## Nightly (1.1.0)
+## VERNEMQ 1.1.0
 
 - Add descriptions to all available metrics via `vmq-admin metrics show
   --with-descriptions`.
 - Add Prometheus HELP lines for every metric.
+- Add a log message (info level) indicating that connectivity to a remote node
+  has been restored.
 
 ## VERNEMQ 1.0.1
 


### PR DESCRIPTION
It is important to be able to see not only that the connectivity to a
remote node has been lost, but also that it has been restored.