### PR TITLE
Don't build on Erlang 19.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,6 @@ language: erlang
 install: true
 otp_release:
     - 18.3
-    - 19.2
     - 19.3
 before_script: "epmd -daemon"
 script: "./rebar3 as all_tests do eunit, ct"


### PR DESCRIPTION
Let's get rid of the 19.2 build (we're building 19.3 anyway and we should switch our docker images to it as well).