### PR TITLE
Fix `message_size_limit` / `max_message_size` bug

### DIFF
--- a/apps/vmq_server/priv/vmq_server.schema
+++ b/apps/vmq_server/priv/vmq_server.schema
@@ -232,22 +232,28 @@
                                                               hidden
                                                              ]}.
 
-%% @doc specifies the maximum incoming MQTT message size.
-%% defaults to 0, which means no limits apply
+%% @doc This option sets the maximum MQTT size that VerneMQ will
+%% allow.  Messages that exceed this size will not be accepted by
+%% VerneMQ. The default value is 0, which means that all valid MQTT
+%% messages are accepted. MQTT imposes a maximum payload size of
+%% 268435455 bytes.
 {mapping, "max_message_size", "vmq_server.max_message_size", [
                                                               {default, 0},
-                                                              {datatype, integer},
-                                                              hidden
+                                                              {datatype, integer}
                                                              ]}.
 
-%% @doc This option sets the maximum payload size that VerneMQ will allow for publishers. 
-%% Messages that exceed this size will not be accepted by VerneMQ. The 
-%% default value is 0, which means that all valid MQTT messages are accepted. MQTT 
-%% imposes a maximum payload size of 268435455 bytes.
+%% @doc deprecated - use `max_message_size` instead.
 {mapping, "message_size_limit", "vmq_server.message_size_limit", [
-                                                                    {default, 0},
-                                                                    {datatype, integer}
+                                                                  {default, 0},
+                                                                  {datatype, integer},
+                                                                  hidden
                                                                  ]}.
+{translation, "vmq_server.message_size_limit",
+ fun(Conf) ->
+         S = cuttlefish:conf_get("message_size_limit", Conf),
+         cuttlefish:warn("message_size_limit is deprecated and has no effect, use max_message_size instead"),
+         S
+ end}.
 
 %% @doc If a message is published with a QoS lower than the QoS of the subscription it is
 %% delivered to, VerneMQ can upgrade the outgoing QoS. This is a non-standard option.

--- a/apps/vmq_server/src/vmq_config_cli.erl
+++ b/apps/vmq_server/src/vmq_config_cli.erl
@@ -41,7 +41,7 @@ register_config_() ->
      "queue_deliver_mode",
      "queue_type",
      "max_message_rate",
-     "message_size_limit",
+     "max_message_size",
      "upgrade_outgoing_qos",
      "systree_enabled",
      "systree_interval",

--- a/apps/vmq_server/src/vmq_mqtt_fsm.erl
+++ b/apps/vmq_server/src/vmq_mqtt_fsm.erl
@@ -92,7 +92,7 @@ init(Peer, Opts) ->
     MaxClientIdSize = vmq_config:get_env(max_client_id_size, 23),
     RetryInterval = vmq_config:get_env(retry_interval, 20),
     MaxInflightMsgs = vmq_config:get_env(max_inflight_messages, 20),
-    MaxMessageSize = vmq_config:get_env(message_size_limit, 0),
+    MaxMessageSize = vmq_config:get_env(max_message_size, 0),
     MaxMessageRate = vmq_config:get_env(max_message_rate, 0),
     UpgradeQoS = vmq_config:get_env(upgrade_outgoing_qos, false),
     RegView = vmq_config:get_env(default_reg_view, vmq_reg_trie),

--- a/apps/vmq_server/src/vmq_server.app.src
+++ b/apps/vmq_server/src/vmq_server.app.src
@@ -30,7 +30,7 @@
       {retry_interval, 20},
       {max_inflight_messages, 20},
       {max_message_rate, 0}, % no rate limit
-      {message_size_limit, 0},
+      {max_message_size, 0}, % no max msg size
       {upgrade_outgoing_qos, false},
       {allow_register_during_netsplit, false},
       {allow_publish_during_netsplit, false},

--- a/apps/vmq_server/test/vmq_publish_SUITE.erl
+++ b/apps/vmq_server/test/vmq_publish_SUITE.erl
@@ -421,8 +421,8 @@ not_allowed_publish_close_qos2_mqtt_3_1_1(_) ->
     {error, closed} = gen_tcp:recv(Socket, 0, 1000).
 
 message_size_exceeded_close(_) ->
-    OldLimit = vmq_config:get_env(message_size_limit),
-    vmq_config:set_env(message_size_limit, 1024, false),
+    OldLimit = vmq_config:get_env(max_message_size),
+    vmq_config:set_env(max_message_size, 1024, false),
     Connect = packet:gen_connect("pub-excessive-test", [{keepalive, 60}]),
     Connack = packet:gen_connack(0),
     Publish = packet:gen_publish("pub/excessive/test", 0, vmq_test_utils:rand_bytes(1024),
@@ -432,7 +432,7 @@ message_size_exceeded_close(_) ->
     ok = gen_tcp:send(Socket, Publish),
     {error, closed} = gen_tcp:recv(Socket, 0, 1000),
     true = lists:member({counter, mqtt_invalid_msg_size_error, 1}, vmq_metrics:metrics()),
-    vmq_config:set_env(message_size_limit, OldLimit, false).
+    vmq_config:set_env(max_message_size, OldLimit, false).
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%% Hooks

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,9 @@
 - Fix tracer `mountpoint` parameter bug.
 - Make it possible to add/inject HTTP API keys.
 - Add Erlang VM memory usage stats to the exposed metrics.
+- Fix bug with `max_message_size` and `message_size_limit` only one of these
+  should exist and `message_size_limit` has now been
+  deprecated. `max_message_size` should be used instead.
 
 ## VERNEMQ 1.1.1
 


### PR DESCRIPTION
Only one option should ever have existed. `message_size_limit` has now
been deprecated and it has no effect if used. Use `max_message_size`
instead.