### PR TITLE
Forget the old plugin code path

### DIFF
--- a/apps/vmq_plugin/src/vmq_plugin_mgr.erl
+++ b/apps/vmq_plugin/src/vmq_plugin_mgr.erl
@@ -545,7 +545,7 @@ check_app_plugin(App, Options) ->
             lager:debug("can't create paths ~p for app ~p", [AppPaths, App]),
             {error, plugin_not_found};
         Paths ->
-            code:add_paths(Paths),
+            code:add_pathsa(Paths),
             load_application(App, Options)
     end.
 

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ## Not yet released
 
+- Fix code path bug related to upgrading plugins.
 - Update `plumtree` with a fix to make the plumtree mailbox traversal
   measurement more accurate and therefore less spammy.
 


### PR DESCRIPTION
With the current implementation we add plugin code paths to the end of the code path and this is state that we manage. If we do not remove it and upgrade a plugin the code path of the new plugin will end up at the end of the code path and calls like `code:lib_dir/1` and `code:priv_dir/1` will return the path of the old plugin.