### PR TITLE
Show complete usage text

### DIFF
--- a/apps/vmq_server/src/vmq_tracer_cli.erl
+++ b/apps/vmq_server/src/vmq_tracer_cli.erl
@@ -112,7 +112,7 @@ trace_client_usage() ->
      "  --rate-interval=<RateIntervalMS>\n",
      "      the interval in milliseconds over which the max number of messages\n",
      "      is allowed. Defaults to 100.\n",
-     "  --trunc-payload=<SizeInByts>\n",
+     "  --trunc-payload=<SizeInBytes>\n",
      "      control when the payload should be truncated for display.\n",
      "      Defaults to 200.\n"
     ].

--- a/apps/vmq_server/src/vmq_tracer_cli.erl
+++ b/apps/vmq_server/src/vmq_tracer_cli.erl
@@ -46,7 +46,7 @@ trace_client_cmd() ->
                 MP = proplists:get_value(mountpoint, Flags, ""),
                 case proplists:get_value('client-id', Keys) of
                     undefined ->
-                        Text = clique_status:text("You have to provide a client-id (example client-id=myclientid)"),
+                        Text = clique_status:text(trace_client_usage()),
                         [clique_status:alert([Text])];
                     CId ->
                         %% the group leader comes from the calling node

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ## Not yet released
 
+- Improve tracer usage text.
 - Fix `vmq_diversity` memcached issue (#460).
 - Fix RPM package issue preventing a clean upgrade.
 - Fix code path bug related to upgrading plugins.


### PR DESCRIPTION
It makes more sense to show the complete usage text instead of a short version without flag descriptions as these would otherwise only be discoverable using `--help`.