### PR TITLE
Add vmql row query time limits

### DIFF
--- a/apps/vmq_ql/src/vmq_ql_parser.peg
+++ b/apps/vmq_ql/src/vmq_ql_parser.peg
@@ -1,15 +1,16 @@
 start <- stmt ~;
 stmt <- select_stmt ~;
 
-select_stmt <- _ select_token _ x:select_field xs:select_field_rest* _ from_token _ from:identifier _ where:where_expr? _ orderby:orderby_expr? _ limit:limit_expr?
- (_ limit_token _ limit:pos_integer)?
+select_stmt <- _ select_token _ x:select_field xs:select_field_rest* _ from_token _ from:identifier _ where:where_expr? _ orderby:orderby_expr? _ limit:limit_expr? _ rowtimeout:rowtimeout_expr?
+
 `
 [{type, "SELECT"}, 
  {fields, [proplists:get_value(x, Node)] ++ proplists:get_value(xs, Node, [])},
  {from, proplists:get_value(from, Node)},
  {where, proplists:get_value(where, Node)},
  {orderby, proplists:get_value(orderby, Node)},
- {limit, proplists:get_value(limit, Node)}]
+ {limit, proplists:get_value(limit, Node)},
+ {rowtimeout, proplists:get_value(rowtimeout, Node)}]
 `;
 select_field <- identifier / select_wildcard ~;
 select_field_rest <- _ separator_token _ s:select_field
@@ -24,6 +25,11 @@ orderby_expr <- orderby_token _ x:orderby_field
 orderby_field <- identifier ~;
 
 limit_expr <- limit_token _ x:pos_integer _
+`
+list_to_integer(binary_to_list(iolist_to_binary(proplists:get_value(x, Node))))
+`;
+
+rowtimeout_expr <- rowtimeout_token _ x:pos_integer _
 `
 list_to_integer(binary_to_list(iolist_to_binary(proplists:get_value(x, Node))))
 `;
@@ -104,6 +110,7 @@ or_token <- 'OR' !ident_rest ~;
 and_token <- 'AND' !ident_rest ~;
 orderby_token <- 'ORDER BY' !ident_rest ~;
 limit_token <- 'LIMIT' !ident_rest ~;
+rowtimeout_token <- 'ROWTIMEOUT' !ident_rest ~;
 
 identifier <- x:ident_start xs:ident_rest*
 `

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,9 @@
 
 ## Not yet released
 
+- Make `vmq-admin session show` more robust when sessions are overloaded by
+  limiting the time allowed to query each session. The default query timeout is
+  100ms, but can be overriden using `--rowtimeout=<TimeoutInMilliseconds>`.
 - Add support for Erlang/OTP20.
 - Improve tracer usage text.
 - Fix `vmq_diversity` memcached issue (#460).


### PR DESCRIPTION
This changes the behaviour of the vmql engine so each row has a limited amount of time to be processed and if the time is exceeded the row is skipped. A skipped row could in the case of `vmq-admin session show` be due to the fact that the client session is overloaded and cannot deliver the data back fast enough.

The current max time to fetch a row is set to 100ms, so if there are 100 clients, all overloaded, then `vmq-admin session show` with default limits (100 results) would take 100*100ms = 10s to return.

Note that if a row is skipped because it is too slow a warning is logged to the VerneMQ logs like `Subquery failed due to timeout`. Unfortunately we can't look anything more descriptive yet - that will be part of a future change.

@dergraf, please note I removed this: https://github.com/erlio/vernemq/compare/master...larshesel:add-vmql-row-query-time-limits?expand=1#diff-55d45ec585d4edfd421a7a92d0d636c7L5 Not sure what it did, but it didn't seem to make a difference either way - so I removed it... Maybe we'll see the travis tests fail ...

This addresses some of the questions in #464 and possible some other open issues.