### PR TITLE
Add ability to add api keys

### DIFF
--- a/apps/vmq_server/src/vmq_http_mgmt_api.erl
+++ b/apps/vmq_server/src/vmq_http_mgmt_api.erl
@@ -27,6 +27,7 @@
 
 -export([routes/0,
          create_api_key/0,
+         add_api_key/1,
          delete_api_key/1,
          list_api_keys/0]).
 
@@ -140,9 +141,13 @@ create_api_key() ->
     Size = size(Chars),
     F = fun() -> element(rand:uniform(Size), Chars) end,
     ApiKey = list_to_binary([ F() || _ <- lists:seq(1,32) ]),
-    Keys = vmq_config:get_env(vmq_server, ?ENV_API_KEYS, []),
-    vmq_config:set_global_env(vmq_server, ?ENV_API_KEYS, [ApiKey|Keys], true),
+    add_api_key(ApiKey),
     ApiKey.
+
+add_api_key(ApiKey) when is_binary(ApiKey) ->
+    Keys = vmq_config:get_env(vmq_server, ?ENV_API_KEYS, []),
+    Keys1 = lists:delete(ApiKey, Keys),
+    vmq_config:set_global_env(vmq_server, ?ENV_API_KEYS, [ApiKey|Keys1], true).
 
 delete_api_key(ApiKey) ->
     case vmq_config:get_env(?ENV_API_KEYS, []) of

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@
 
 - Log when a client is disconnected and multiple sessions are not allowed.
 - Fix tracer `mountpoint` parameter bug.
+- Make it possible to add/inject HTTP API keys.
 
 ## VERNEMQ 1.1.1
 


### PR DESCRIPTION
Note, this also fixes the crash when just writing `vmq-admin api-key delete` by adding a fall-through which displays the help text.