### PR TITLE
Fix expire_session bug

### DIFF
--- a/apps/vmq_server/src/vmq_queue.erl
+++ b/apps/vmq_server/src/vmq_queue.erl
@@ -866,7 +866,7 @@ maybe_set_expiry_timer(0, State) ->
     %% never expire
     State;
 maybe_set_expiry_timer(ExpireAfter, State) when ExpireAfter > 0 ->
-    Ref = erlang:send_after(ExpireAfter * 1000, self(), expire_session),
+    Ref = gen_fsm:send_event_after(ExpireAfter * 1000, expire_session),
     State#state{expiry_timer=Ref}.
 
 maybe_offline_store(Offline, SubscriberId, {deliver, QoS, #vmq_msg{persisted=false} = Msg}) when QoS > 0 ->
@@ -904,7 +904,7 @@ maybe_offline_delete(_, _) -> ok.
 
 unset_expiry_timer(#state{expiry_timer=undefined} = State) -> State;
 unset_expiry_timer(#state{expiry_timer=Ref} = State) ->
-    erlang:cancel_timer(Ref),
+    gen_fsm:cancel_timer(Ref),
     State#state{expiry_timer=undefined}.
 
 state_change(Msg, OldStateName, NewStateName) ->

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,8 @@
 
 ## Not yet released
 
+- Fix bug preventing persistent session expiration
+  (`persistent_client_expiration` in `vernemq.conf`) from being executed.
 - Make `vmq-admin session show` more robust when sessions are overloaded by
   limiting the time allowed to query each session. The default query timeout is
   100ms, but can be overriden using `--rowtimeout=<TimeoutInMilliseconds>`.


### PR DESCRIPTION
The persistent_client_expiration feature has been broken for a while apparently - the code looked like it was from before the queue was implemented as an fsm...