### PR TITLE
Use wrapper for mongo client to protect poolboy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,12 @@ services:
     - memcached
 
 before_install:
-    - mysql -e "CREATE DATABASE test_database;" -uroot
-    - mysql -e "CREATE USER 'test_user' IDENTIFIED BY 'test_password';" -uroot
-    - mysql -e "GRANT ALL PRIVILEGES ON * . * TO 'test_user';" -uroot
-    - psql -c "CREATE DATABASE test_database;" -U postgres
-    - psql -c "CREATE USER test_user WITH PASSWORD 'test_password';" -U postgres
-    - psql -c "GRANT ALL PRIVILEGES ON DATABASE test_database to test_user;" -U postgres
+    - mysql -e "CREATE DATABASE vmq_test_database;" -uroot
+    - mysql -e "CREATE USER 'vmq_test_user' IDENTIFIED BY 'vmq_test_password';" -uroot
+    - mysql -e "GRANT ALL PRIVILEGES ON * . * TO 'vmq_test_user';" -uroot
+    - psql -c "CREATE DATABASE vmq_test_database;" -U postgres
+    - psql -c "CREATE USER vmq_test_user WITH PASSWORD 'vmq_test_password';" -U postgres
+    - psql -c "GRANT ALL PRIVILEGES ON DATABASE vmq_test_database to vmq_test_user;" -U postgres
 
 sudo: required
 dist: trusty

--- a/apps/vmq_diversity/src/vmq_diversity_mongo.erl
+++ b/apps/vmq_diversity/src/vmq_diversity_mongo.erl
@@ -21,27 +21,27 @@
 
 insert(PoolName, Collection, DocOrDocs) ->
     poolboy:transaction(PoolName, fun(Worker) ->
-                                          mongo:insert(Worker, Collection, DocOrDocs)
+                                          vmq_diversity_worker_wrapper:apply(Worker, mongo, insert, [Collection, DocOrDocs])
                                   end).
 
 update(PoolName, Collection, Selector, Command) ->
     poolboy:transaction(PoolName, fun(Worker) ->
-                                          mongo:update(Worker, Collection, Selector, Command)
+                                          vmq_diversity_worker_wrapper:apply(Worker, mongo, update, [Collection, Selector, Command])
                                   end).
 
 delete(PoolName, Collection, Selector) ->
     poolboy:transaction(PoolName, fun(Worker) ->
-                                          mongo:delete(Worker, Collection, Selector)
+                                          vmq_diversity_worker_wrapper:apply(Worker, mongo, delete, [Collection, Selector])
                                   end).
 
 find(PoolName, Collection, Selector, Args) ->
     poolboy:transaction(PoolName, fun(Worker) ->
-                                          mongo:find(Worker, Collection, Selector, Args)
+                                          vmq_diversity_worker_wrapper:apply(Worker, mongo, find, [Collection, Selector, Args])
                                   end).
 
 find_one(PoolName, Collection, Selector, Args) ->
     poolboy:transaction(PoolName, fun(Worker) ->
-                                          mongo:find_one(Worker, Collection, Selector, Args)
+                                          vmq_diversity_worker_wrapper:apply(Worker, mongo, find_one, [Collection, Selector, Args])
                                   end).
 
 install(St) ->

--- a/apps/vmq_diversity/src/vmq_diversity_postgres.erl
+++ b/apps/vmq_diversity/src/vmq_diversity_postgres.erl
@@ -14,155 +14,31 @@
 
 -module(vmq_diversity_postgres).
 
--behaviour(gen_server).
--behaviour(poolboy_worker).
-
 %% API functions
--export([start_link/1,
-        install/1,
-        squery/2,
-        equery/3]).
-
-%% gen_server callbacks
--export([init/1,
-         handle_call/3,
-         handle_cast/2,
-         handle_info/2,
-         terminate/2,
-         code_change/3]).
+-export([install/1,
+         squery/2,
+         equery/3]).
 
 -import(luerl_lib, [badarg_error/3]).
-
--record(state, {conn}).
 
 %%%===================================================================
 %%% API functions
 %%%===================================================================
 
-%%--------------------------------------------------------------------
-%% @doc
-%% Starts the server
-%%
-%% @spec start_link() -> {ok, Pid} | ignore | {error, Error}
-%% @end
-%%--------------------------------------------------------------------
-start_link(Args) ->
-    gen_server:start_link(?MODULE, Args, []).
-
 install(St) ->
     luerl_emul:alloc_table(table(), St).
 
 squery(PoolName, Sql) ->
-    poolboy:transaction(PoolName, fun(Worker) ->
-                                          gen_server:call(Worker, {squery, Sql})
-                                  end).
+    poolboy:transaction(PoolName,
+                        fun(Worker) ->
+                                vmq_diversity_worker_wrapper:apply(Worker, epgsql, squery, [Sql])
+                        end).
 
 equery(PoolName, Stmt, Params) ->
-    poolboy:transaction(PoolName, fun(Worker) ->
-                                          gen_server:call(Worker, {equery, Stmt, Params})
-                                  end).
-
-
-%%%===================================================================
-%%% gen_server callbacks
-%%%===================================================================
-
-%%--------------------------------------------------------------------
-%% @private
-%% @doc
-%% Initializes the server
-%%
-%% @spec init(Args) -> {ok, State} |
-%%                     {ok, State, Timeout} |
-%%                     ignore |
-%%                     {stop, Reason}
-%% @end
-%%--------------------------------------------------------------------
-init(Args) ->
-    process_flag(trap_exit, true),
-    Hostname = proplists:get_value(host, Args, "localhost"),
-    Port = proplists:get_value(port, Args, 5432),
-    Database = proplists:get_value(database, Args),
-    Username = proplists:get_value(user, Args),
-    Password = proplists:get_value(password, Args),
-    {ok, Conn} = epgsql:connect(Hostname, Username, Password, [
-        {database, Database},
-        {port, Port}
-    ]),
-    {ok, #state{conn=Conn}}.
-
-%%--------------------------------------------------------------------
-%% @private
-%% @doc
-%% Handling call messages
-%%
-%% @spec handle_call(Request, From, State) ->
-%%                                   {reply, Reply, State} |
-%%                                   {reply, Reply, State, Timeout} |
-%%                                   {noreply, State} |
-%%                                   {noreply, State, Timeout} |
-%%                                   {stop, Reason, Reply, State} |
-%%                                   {stop, Reason, State}
-%% @end
-%%--------------------------------------------------------------------
-handle_call({squery, Sql}, _From, #state{conn=Conn}=State) ->
-    {reply, epgsql:squery(Conn, Sql), State};
-handle_call({equery, Stmt, Params}, _From, #state{conn=Conn}=State) ->
-    {reply, epgsql:equery(Conn, Stmt, Params), State};
-handle_call(_Request, _From, State) ->
-    {reply, ok, State}.
-
-%%--------------------------------------------------------------------
-%% @private
-%% @doc
-%% Handling cast messages
-%%
-%% @spec handle_cast(Msg, State) -> {noreply, State} |
-%%                                  {noreply, State, Timeout} |
-%%                                  {stop, Reason, State}
-%% @end
-%%--------------------------------------------------------------------
-handle_cast(_Msg, State) ->
-    {noreply, State}.
-
-%%--------------------------------------------------------------------
-%% @private
-%% @doc
-%% Handling all non call/cast messages
-%%
-%% @spec handle_info(Info, State) -> {noreply, State} |
-%%                                   {noreply, State, Timeout} |
-%%                                   {stop, Reason, State}
-%% @end
-%%--------------------------------------------------------------------
-handle_info(_Info, State) ->
-    {noreply, State}.
-
-%%--------------------------------------------------------------------
-%% @private
-%% @doc
-%% This function is called by a gen_server when it is about to
-%% terminate. It should be the opposite of Module:init/1 and do any
-%% necessary cleaning up. When it returns, the gen_server terminates
-%% with Reason. The return value is ignored.
-%%
-%% @spec terminate(Reason, State) -> void()
-%% @end
-%%--------------------------------------------------------------------
-terminate(_Reason, State) ->
-    ok = epgsql:close(State#state.conn),
-    ok.
-
-%%--------------------------------------------------------------------
-%% @private
-%% @doc
-%% Convert process state when code is changed
-%%
-%% @spec code_change(OldVsn, State, Extra) -> {ok, NewState}
-%% @end
-%%--------------------------------------------------------------------
-code_change(_OldVsn, State, _Extra) ->
-    {ok, State}.
+    poolboy:transaction(PoolName,
+                        fun(Worker) ->
+                                vmq_diversity_worker_wrapper:apply(Worker, epgsql, equery, [Stmt, Params])
+                        end).
 
 %%%===================================================================
 %%% Internal functions
@@ -203,11 +79,13 @@ execute(As, St) ->
                 {ok, _, _Columns, _Rows} ->
                     %% INSERT success
                     {[true], St};
+                {error, not_connected} = E ->
+                    throw(E);
                 {error, _Error} ->
                     {[false], St}
             catch
                 E:R ->
-                    lager:error("can't execute query ~p due to ~p", [BQuery, E, R]),
+                    lager:error("can't execute query ~p due to ~p", [BQuery, {E, R}]),
                     badarg_error(execute_equery, As, St)
             end;
         _ ->

--- a/apps/vmq_diversity/src/vmq_diversity_worker_wrapper.erl
+++ b/apps/vmq_diversity/src/vmq_diversity_worker_wrapper.erl
@@ -1,0 +1,221 @@
+%% Copyright 2017 Erlio GmbH Basel Switzerland (http://erl.io)
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+
+%% @doc Simple gen_server for poolboy used to wrap a client process
+%% and restart (after a configurable timeout) it if it dies for some
+%% reason. The purpose is to protect poolboy from dying if an external
+%% resource is not available and all the client processes die.
+%% @end.
+-module(vmq_diversity_worker_wrapper).
+
+-behaviour(poolboy_worker).
+-behaviour(gen_server).
+
+%% API
+-export([start_link/1, apply/4]).
+
+%% gen_server callbacks
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2,
+         terminate/2, code_change/3]).
+
+-define(SERVER, ?MODULE).
+
+-record(state, {
+          %% Name used for logging purposes.
+          name = undefined,
+
+          %% fun of arity 0 to start the worker.
+          start_fun = undefined,
+
+          %% fun of arity 1 used to terminate the worker when shutting
+          %% down.
+          terminate_fun = undefined,
+
+          %% The worker PID if running.
+          worker = undefined :: {reference(), pid()},
+
+          %% Is the client process ready?
+          connected = false :: boolean(),
+          
+          %% Reconnect timeout if the connection is lost (the worker
+          %% process dies).
+          reconnect_timeout
+         }).
+
+%%%===================================================================
+%%% API
+%%%===================================================================
+
+%%--------------------------------------------------------------------
+%% @doc
+%% Starts the server
+%%
+%% @spec start_link() -> {ok, Pid} | ignore | {error, Error}
+%% @end
+%%--------------------------------------------------------------------
+start_link(Opts) ->
+    gen_server:start_link(?MODULE, Opts, []).
+
+apply(Pid, Mod, Fun, Args) ->
+    gen_server:call(Pid, {apply, Mod, Fun, Args}).
+
+%%%===================================================================
+%%% gen_server callbacks
+%%%===================================================================
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% Initializes the server
+%%
+%% @spec init(Args) -> {ok, State} |
+%%                     {ok, State, Timeout} |
+%%                     ignore |
+%%                     {stop, Reason}
+%% @end
+%%--------------------------------------------------------------------
+init(Opts) ->
+    process_flag(trap_exit, true),
+    self() ! connect,
+    Name = proplists:get_value(name, Opts),
+    StartFun = proplists:get_value(start_fun, Opts),
+    true = is_function(StartFun, 0),
+    TerminateFun = proplists:get_value(terminate_fun, Opts),
+    true = TerminateFun =:= undefined orelse is_function(TerminateFun, 1),
+    ReconnectTimetout = proplists:get_value(reconnect_timeout, Opts, 1000),
+    {ok, #state{name = Name,
+                start_fun = StartFun,
+                terminate_fun = TerminateFun,
+                reconnect_timeout = ReconnectTimetout,
+                connected=false,
+                worker=undefined}}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% Handling call messages
+%%
+%% @spec handle_call(Request, From, State) ->
+%%                                   {reply, Reply, State} |
+%%                                   {reply, Reply, State, Timeout} |
+%%                                   {noreply, State} |
+%%                                   {noreply, State, Timeout} |
+%%                                   {stop, Reason, Reply, State} |
+%%                                   {stop, Reason, State}
+%% @end
+%%--------------------------------------------------------------------
+handle_call({apply, _,_,_}, _From, #state{connected=false}=State) ->
+    {reply, {error, not_connected}, State};
+handle_call({apply, Mod, Fun, Args}, _From, #state{worker={_MRef, Pid}}=State) when is_pid(Pid) ->
+    Reply =
+        try
+            erlang:apply(Mod, Fun, [Pid|Args])
+        catch
+            exit:{noproc,_Reason} ->
+                %% We remove the worker pid only in handle_info where
+                %% the attempt to restart the process will also be
+                %% kicked off.
+                {error, not_connected}
+        end,
+    {reply, Reply, State}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% Handling cast messages
+%%
+%% @spec handle_cast(Msg, State) -> {noreply, State} |
+%%                                  {noreply, State, Timeout} |
+%%                                  {stop, Reason, State}
+%% @end
+%%--------------------------------------------------------------------
+handle_cast(_Msg, State) ->
+    {noreply, State}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% Handling all non call/cast messages
+%%
+%% @spec handle_info(Info, State) -> {noreply, State} |
+%%                                   {noreply, State, Timeout} |
+%%                                   {stop, Reason, State}
+%% @end
+%%--------------------------------------------------------------------
+handle_info(connect, #state{start_fun=StartFun,name=Name,worker=undefined,connected=false} = State) ->
+    NewState =
+    case StartFun() of
+        {ok, Pid} ->
+            MRef = monitor(process, Pid),
+            State#state{worker={MRef, Pid},connected=true};
+        {error, Reason} ->
+            lager:warning("Could not connect to ~p due to ~p",
+                          [Name, Reason]),
+            schedule_reconnect(State),
+            State
+    end,
+    {noreply, NewState};
+handle_info({'DOWN', MRef, process, WorkerPid, _}, #state{worker={MRef, WorkerPid}}=S) ->
+    schedule_reconnect(S),
+    {noreply, S#state{worker=undefined, connected=false}};
+handle_info({'EXIT',WorkerPid,_}, #state{worker={_MRef, WorkerPid}}=S) ->
+    %% We got an exit - let's wait for the monitor signal to arrive
+    %% before cleaning up and scheduling a reconnect, but mark the
+    %% connection as down.
+    {noreply, S#state{connected=false}};
+handle_info({'EXIT',_,_}, #state{worker=undefined,connected=false}=S) ->
+    %% Got an exit when starting the client process. schedule a
+    %% reconnect.
+    schedule_reconnect(S),
+    {noreply, S};
+handle_info(_, S) ->
+    {noreply, S}.
+
+
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% This function is called by a gen_server when it is about to
+%% terminate. It should be the opposite of Module:init/1 and do any
+%% necessary cleaning up. When it returns, the gen_server terminates
+%% with Reason. The return value is ignored.
+%%
+%% @spec terminate(Reason, State) -> void()
+%% @end
+%%--------------------------------------------------------------------
+terminate(_Reason, #state{terminate_fun=TFun, worker={_Mref, Pid}})
+  when TFun =:= undefined ->
+    TFun(Pid),
+    ok;
+terminate(_Reason, _State) ->
+    ok.
+
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% Convert process state when code is changed
+%%
+%% @spec code_change(OldVsn, State, Extra) -> {ok, NewState}
+%% @end
+%%--------------------------------------------------------------------
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+%%%===================================================================
+%%% Internal functions
+%%%===================================================================
+schedule_reconnect(#state{reconnect_timeout=Timeout}) ->
+    erlang:send_after(Timeout, self(), connect).

--- a/apps/vmq_diversity/test/mongodb_error_test.lua
+++ b/apps/vmq_diversity/test/mongodb_error_test.lua
@@ -1,0 +1,20 @@
+config = {
+    pool_id = "mongodb_test",
+    size = 1,
+    w_mode = "safe",
+    -- hopefully there's no monbodb instance on this port
+    port = 12345
+}
+
+assert(mongodb.ensure_pool(config))
+
+function auth_on_register(reg)
+   -- if not connected to mongo this should abort the script and
+   -- return an error to the hook caller.
+   mongodb.delete("mongodb_test", "users", {})
+   return true
+end
+
+hooks = {
+    auth_on_register = auth_on_register
+}

--- a/apps/vmq_diversity/test/mysql_test.lua
+++ b/apps/vmq_diversity/test/mysql_test.lua
@@ -2,9 +2,9 @@
 config = {
     pool_id = "mysql_test",
     size = 5,
-    user = "test_user",
-    password = "test_password",
-    database = "test_database",
+    user = "vmq_test_user",
+    password = "vmq_test_password",
+    database = "vmq_test_database",
     host = "localhost",
     port = 3306
 }

--- a/apps/vmq_diversity/test/postgres_error_test.lua
+++ b/apps/vmq_diversity/test/postgres_error_test.lua
@@ -1,0 +1,21 @@
+config = {
+    pool_id = "postgres_test",
+    user = "vmq_test_user",
+    password = "vmq_test_password",
+    database = "vmq_test_database",
+    -- hopefully there's no postgresql instance on this port
+    port = 12345
+}
+
+postgres.ensure_pool(config)
+
+function auth_on_register(reg)
+   -- if not connected to postgres this should abort the script and
+   -- return an error to the hook caller.
+   postgres.execute("postgres_test", "DROP TABLE IF EXISTS postgres_test_lua_tbl")
+   return true
+end
+
+hooks = {
+    auth_on_register = auth_on_register
+}

--- a/apps/vmq_diversity/test/postgres_test.lua
+++ b/apps/vmq_diversity/test/postgres_test.lua
@@ -1,8 +1,8 @@
 config = {
     pool_id = "postgres_test",
-    user = "test_user",
-    password = "test_password",
-    database = "test_database"
+    user = "vmq_test_user",
+    password = "vmq_test_password",
+    database = "vmq_test_database"
 }
 
 postgres.ensure_pool(config)

--- a/apps/vmq_diversity/test/vmq_diversity_provider_SUITE.erl
+++ b/apps/vmq_diversity/test/vmq_diversity_provider_SUITE.erl
@@ -10,7 +10,9 @@
 
 -export([mysql_test/1,
          postgres_test/1,
+         postgres_error_test/1,
          mongodb_test/1,
+         mongodb_error_test/1,
          redis_test/1,
          http_test/1,
          kv_test/1,
@@ -81,8 +83,16 @@ mysql_test(_) ->
 postgres_test(_) ->
     {ok, _} = vmq_diversity:load_script(test_script("postgres_test.lua")).
 
+postgres_error_test(_) ->
+    {ok, _} = vmq_diversity:load_script(test_script("postgres_error_test.lua")),
+    error = vmq_diversity_plugin:auth_on_register({{127,0,0,1}, 1234}, {"", <<"clientid">>}, <<"username">>, <<"password">>, true).
+
 mongodb_test(_) ->
     {ok, _} = vmq_diversity:load_script(test_script("mongodb_test.lua")).
+
+mongodb_error_test(_) ->
+    {ok, _} = vmq_diversity:load_script(test_script("mongodb_error_test.lua")),
+    error = vmq_diversity_plugin:auth_on_register({{127,0,0,1}, 1234}, {"", <<"clientid">>}, <<"username">>, <<"password">>, true).
 
 redis_test(_) ->
     {ok, _} = vmq_diversity:load_script(test_script("redis_test.lua")).

--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,10 @@
 - Fix bug with `max_message_size` and `message_size_limit` only one of these
   should exist and `message_size_limit` has now been
   deprecated. `max_message_size` should be used instead.
+- Fix bug in `vmq_diversity` where the MongoDB client pool would not reconnect
+  after a MongDB restart (#475).
+- Fix bug in `vmq_diversity` where the PostgreSQL client pool would not reconnect
+  after a PostgreSQL restart (same as #475).
 
 ## VERNEMQ 1.1.1
 


### PR DESCRIPTION
Use wrapper for mongo client to protect poolboy if the mongodb database
is not available.

I think we'd need to do the same for the postgres and maybe other drivers, but I thought I'd get the approach reviewed first. The wrapper I wrote I tried to keep general with the hope we can use it for other cases as well.

This is a first step toward fixing #475 