### PR TITLE
Fix shutdown deadlock issue

### DIFF
--- a/apps/vmq_diversity/src/vmq_diversity_sup.erl
+++ b/apps/vmq_diversity/src/vmq_diversity_sup.erl
@@ -48,8 +48,8 @@ start_link() ->
 init([]) ->
     {ok, { {one_for_all, 0, 1},
            [
-            ?CHILD(vmq_diversity_plugin, vmq_diversity_plugin, worker, []),
             ?CHILD(vmq_diversity_script_sup, vmq_diversity_script_sup, supervisor, []),
+            ?CHILD(vmq_diversity_plugin, vmq_diversity_plugin, worker, []),
             ?CHILD(vmq_diversity_cache, vmq_diversity_cache, worker, [])
            ]}
     }.


### PR DESCRIPTION
When stopping the `vmq_diversity` plugin using
`vmq_plugin_mgr:disable_plugin(vmq_diversity)` and lua hooks have been
registered, then when `vmq_diversity_script` is stopped this will cause
`DOWN` messages to be sent to the `vmq_diversity_plugin` process which
in turn calls into `vmq_plugin_mgr:disable_module_plugin/3` causing a
deadlock.

To mitigate this start/shutdown order was changed so
`vmq_diversity_plugin` is shutdown before `vmq_diversity_script`. `DOWN`
messages can still arrive due to normal circumstances when the plugin is
being disable, but this happening should be exceedingly rare.

Fixes #492 