### PR TITLE
Use otp20 compatible rebar3_cuttlefish

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -2,7 +2,9 @@
 {minimum_otp_vsn, "18.0"}.
 {erl_opts, [debug_info, fail_on_warning,
             {platform_define, "20", otp20}]}.
-{project_plugins, [rebar3_cuttlefish]}.
+{project_plugins, [
+                   {rebar3_cuttlefish, {git, "git://github.com/larshesel/rebar3_cuttlefish",
+                                        {branch, "use-otp20-compatibly-cuttlefish"}}}]}.
 {dialyzer, [{exclude_mods, [vmq_plugin]}]}.
 
 {deps, [


### PR DESCRIPTION
For some reason we're now getting the cuttlefish binary from the rebar3_cuttlefish plugin which also pulls in it's own version of cuttlefish which is not OTP20 compatible.


I'll see if I can get these things upstream and preferable things pushed to hex as well...