### PR TITLE
Fix retained msg persistence/replication race issue

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,8 @@
 
 ## Not yet released
 
+- Fix retain msg server race condition preventing some messages from being
+  persisted and replicated to other nodes in the cluster (#507).
 - Log when a client is disconnected and multiple sessions are not allowed.
 - Fix tracer `mountpoint` parameter bug.
 - Make it possible to add/inject HTTP API keys.


### PR DESCRIPTION
Persisting retained messages to plumtree is handled within the
`vmq_retain_src` gen_server by folding over the `?RETAIN_UPDATE` ets
table. After this fold is complete all objects in the `?RETAIN_UPDATE`
table are deleted.

This creates a race-condition as new retained messages are inserted
into the `?RETAIN_UPDATE` table *outside* of the `vmq_retain_src`
gen_server and it is therefore possible that rows are inserted between
the fold has finished and the objects are deleted, thus some updates
will be forgotten and never persisted (and therefore never replicated
to remote nodes!)

The naïve approach would be to move the insertions into the ETS table
into the `vmq_retain_src` gen_server, but having to call into a
gen_server for each retained message would likely quickly become a
bottleneck.

Another approach would be to only delete the entries from the
`?RETAIN_UPDATE` table we've persisted. But even that is prone to a
race-condition because a new update could happen between reading from
the table and deleting the entry. This race-condition would be much
more rare than the one above where all objects are deleted in bulk.

The solution is to use a counter. Each update  a counter
and every time an object is persisted the counter is
decremented. After the persist fold we delete all elements which have
a counter of zero (no pending updates).

This approach means we may write the same value more than once, which
is a good tradeoff compared to losing the value entirely.