### PR TITLE
Fix vmq ql bug

### DIFF
--- a/apps/vmq_ql/src/vmq_ql_query.erl
+++ b/apps/vmq_ql/src/vmq_ql_query.erl
@@ -405,12 +405,7 @@ v(<<"<", _/binary>> = MaybePid) ->
     catch
         _:_ -> MaybePid
     end;
-v(V) ->
-    try
-        binary_to_existing_atom(V, utf8)
-    catch
-        _:_ -> V
-    end.
+v(V) -> V.
 
 lookup_ident(Ident) ->
     Row = get({?MODULE, row_data}),

--- a/apps/vmq_ql/test/vmq_ql_SUITE.erl
+++ b/apps/vmq_ql/test/vmq_ql_SUITE.erl
@@ -11,7 +11,6 @@
          query_select_all_test/1,
          query_select_by_id_test/1,
          query_select_match_test/1,
-         query_select_by_atom_test/1,
          query_select_by_pid_test/1
         ]).
 
@@ -29,7 +28,6 @@ all() ->
      query_select_all_test,
      query_select_by_id_test,
      query_select_match_test,
-     query_select_by_atom_test,
      query_select_by_pid_test
     ].
 
@@ -74,11 +72,6 @@ query_select_by_id_test(_) ->
 
 query_select_match_test(_) ->
     Query = "SELECT * FROM modules WHERE path MATCH \".+" ++ atom_to_list(?MODULE) ++ ".beam\"",
-    Pid =  query(Query),
-    [{1, #{module := ?MODULE}}] = fetch(Pid, 10).
-
-query_select_by_atom_test(_) ->
-    Query = "SELECT * FROM modules WHERE module = \"" ++ atom_to_list(?MODULE) ++ "\"",
     Pid =  query(Query),
     [{1, #{module := ?MODULE}}] = fetch(Pid, 10).
 

--- a/apps/vmq_server/src/vmq_info.erl
+++ b/apps/vmq_server/src/vmq_info.erl
@@ -92,7 +92,7 @@ session_info_items() ->
 fold_init_rows(_, Fun, Acc) ->
     vmq_queue_sup_sup:fold_queues(
       fun({MP, ClientId}, QPid, AccAcc) ->
-              InitRow = #{node => node(),
+              InitRow = #{node => atom_to_binary(node(),utf8),
                           mountpoint => list_to_binary(MP),
                           '__mountpoint' => MP,
                           client_id => ClientId,

--- a/apps/vmq_server/src/vmq_mqtt_fsm.erl
+++ b/apps/vmq_server/src/vmq_mqtt_fsm.erl
@@ -1138,7 +1138,7 @@ get_info_items([peer_host|Rest], State, Acc) ->
     Host =
     case inet:gethostbyaddr(PeerIp) of
         {ok, {hostent, HostName, _, inet, _, _}} ->  HostName;
-        _ -> PeerIp
+        _ -> list_to_binary(inet:ntoa(PeerIp))
     end,
     get_info_items(Rest, State, [{peer_host, Host}|Acc]);
 get_info_items([protocol|Rest], State, Acc) ->

--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,9 @@
 
 ## Not yet released
 
-- Fix issue causing too few results to be returned from `vmq-admin session show`
+- Make sure the `peer_host` can always be retrieved via the HTTP API. It was
+  returned as an erlang tuple which caused the conversion to JSON to fail.
+- Fix issue causing too few results to be returned from `vmq-admin sessiono show`
   when used with filter options. This could happen when terms included in the
   filters also existed as erlang atoms.
 - Plugin workflow improvements: move plugin development specific things into

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,9 @@
 
 ## Not yet released
 
+- Fix issue causing too few results to be returned from `vmq-admin session show`
+  when used with filter options. This could happen when terms included in the
+  filters also existed as erlang atoms.
 - Plugin workflow improvements: move plugin development specific things into
   `vernemq_dev`.
 - Fix error in the HTTP API interface. The alias `/api/v1/sessions` mapped to


### PR DESCRIPTION
This fixes two bugs: one is the vmq_ql search terms which coincides with erlang atoms preventing results from being returned, the other is to display `peer_host` as a binary instead of a tuple if no hostname could be found.

Fixes at least one part of #526 