### PR TITLE
Handle uncaught error type

### DIFF
--- a/apps/vmq_ql/src/vmq_ql_query.erl
+++ b/apps/vmq_ql/src/vmq_ql_query.erl
@@ -136,6 +136,8 @@ internal_query(Str) ->
     try vmq_ql_parser:parse(Str) of
         {fail, E} ->
             {error, E};
+        {_Parsed,Unparsed,Loc} ->
+            {error, {parse_error,Unparsed,Loc}};
         Parsed when is_list(Parsed) ->
             eval(proplists:get_value(type, Parsed), Parsed)
     catch

--- a/changelog.md
+++ b/changelog.md
@@ -2,9 +2,10 @@
 
 ## Not yet released
 
+- Handle uncaught error type in the `vmq_ql_query` handler.
 - Make sure the `peer_host` can always be retrieved via the HTTP API. It was
   returned as an erlang tuple which caused the conversion to JSON to fail.
-- Fix issue causing too few results to be returned from `vmq-admin sessiono show`
+- Fix issue causing too few results to be returned from `vmq-admin session show`
   when used with filter options. This could happen when terms included in the
   filters also existed as erlang atoms.
 - Plugin workflow improvements: move plugin development specific things into


### PR DESCRIPTION
This fix handles when the parser returns:

```erlang
4> vmq_ql_parser:parse("SELECT peer_host FROM sessions WHERE client_id=\"client\" and mountpoint=\"\""). 
{[{type,"SELECT"},
  {fields,[peer_host]},
  {from,sessions},
  {where,[{op,client_id,equals,<<"client">>}]},
  {orderby,[]},
  {limit,[]},
  {rowtimeout,[]}],
 <<"and mountpoint=\"\"">>,
 {{line,1},{column,57}}}
```

And we now get the error (instead of `fold_query` hanging):
```erlang
> vmq_ql_query_mgr:fold_query(fun(Row,Acc) -> [Row|Acc] end, [], ["SELECT session_pid, queue_pid FROM sessions WHERE client_id=", <<"\"client\"">>, " and mountpoint=\"\""]).
Query had errors [{parse_error,<<"and mountpoint=\"\"">>,
                               {{line,1},{column,70}}}]
```