### PR TITLE
Prevent unbounded memory usage in plumtree during a netsplit

### DIFF
--- a/apps/vmq_server/priv/vmq_server.schema
+++ b/apps/vmq_server/priv/vmq_server.schema
@@ -1455,6 +1455,12 @@
                                              hidden
                                             ]}.
 
+{mapping, "plumtree.outstandind_limit", "plumtree.outstanding_limit", [
+                                                                       {default, 250000},
+                                                                       {datatype, integer},
+                                                                       hidden
+                                                                      ]}.
+
 %% the setup utility will call hooks to create the default directories,
 %% however the setup defaults e.g. data.<nodename> are not matching with our 
 %% defaults, so we need to override them.

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,9 @@
 
 ## Not yet released
 
+- Prevent unbounded memory growth in a netsplit situation by putting an explicit
+  limit (250K) on the number of outstanding plumtree-msgs in plumtree. If this
+  limit is exceeded, delayed replication will be handled by active entropy.
 - Handle uncaught error type in the `vmq_ql_query` handler.
 - Make sure the `peer_host` can always be retrieved via the HTTP API. It was
   returned as an erlang tuple which caused the conversion to JSON to fail.

--- a/rebar.lock
+++ b/rebar.lock
@@ -80,7 +80,7 @@
   1},
  {<<"plumtree">>,
   {git,"git://github.com/erlio/plumtree.git",
-       {ref,"abb73ffb9e0e8f05a1c28dfac5e4e1a4d8637dee"}},
+       {ref,"05796c6516e65bb844c39a6aff4b8f9958fe9722"}},
   0},
  {<<"poolboy">>,{pkg,<<"poolboy">>,<<"1.5.1">>},0},
  {<<"ranch">>,{pkg,<<"ranch">>,<<"1.2.1">>},0},


### PR DESCRIPTION
Some things to consider:

Can this be part of 1.2.1 as a bugfix or is it a new feature for 1.3.0? I would think this is important enough to be shipped as a bugfix even though it introduces a new config value (though hidden).

Secondly, should the config value be hidden? I'm not sure - for now it's set to 10000 plumtree msgs which means 10MB memory usage at 1K / msg.

Thirdly, what would a good default value be? 10000 was just a guess.