### PR TITLE
Add simple hints to vmq-ql queries

### DIFF
--- a/apps/vmq_ql/src/vmq_ql_query.erl
+++ b/apps/vmq_ql/src/vmq_ql_query.erl
@@ -413,11 +413,11 @@ eval_op(Op, V1, V2) ->
 
 eval_op_norm(Op, V1, V2) when is_atom(V1), is_binary(V2) ->
     eval_op_(Op, atom_to_binary(V1, utf8), V2);
-eval_op_norm(Op, V1, V2) when is_binary(V1), is_atom(V1) ->
+eval_op_norm(Op, V1, V2) when is_binary(V1), is_atom(V2) ->
     eval_op_(Op, V1, atom_to_binary(V2, utf8));
 eval_op_norm(Op, V1, V2) when is_list(V1), is_binary(V2) ->
     eval_op_(Op, list_to_binary(V1), V2);
-eval_op_norm(Op, V1, V2) when is_binary(V1), is_list(V1) ->
+eval_op_norm(Op, V1, V2) when is_binary(V1), is_list(V2) ->
     eval_op_(Op, V1, list_to_binary(V2));
 eval_op_norm(Op, V1, V2) ->
     eval_op_(Op, V1, V2).

--- a/apps/vmq_ql/src/vmq_ql_sys_info.erl
+++ b/apps/vmq_ql/src/vmq_ql_sys_info.erl
@@ -17,7 +17,7 @@
 -include("vmq_ql.hrl").
 
 -export([fields_config/0,
-         fold_init_rows/3]).
+         fold_init_rows/4]).
 
 fields_config() ->
     ProcessBase = #vmq_ql_table{
@@ -31,7 +31,7 @@ fields_config() ->
 
     [ProcessBase].
 
-fold_init_rows(_, Fun, Acc) ->
+fold_init_rows(_, Fun, Acc, _) ->
     lists:foldl(
       fun(Pid, AccAcc) ->
               InitRow = #{node => atom_to_binary(node(), utf8),

--- a/apps/vmq_ql/test/vmq_ql_SUITE.erl
+++ b/apps/vmq_ql/test/vmq_ql_SUITE.erl
@@ -15,7 +15,7 @@
         ]).
 
 %% vmq_ql exports
--export([fields_config/0, fold_init_rows/3]).
+-export([fields_config/0, fold_init_rows/4]).
 
 -include("vmq_ql.hrl").
 -include_lib("common_test/include/ct.hrl").
@@ -115,12 +115,12 @@ fields_config() ->
              },
     [Foo, Bar, Mods].
 
-fold_init_rows(foobar, Fun, Acc) ->
+fold_init_rows(foobar, Fun, Acc,_) ->
     lists:foldl(fun(I, AccAcc) ->
                         InitRow = #{id => I},
                         Fun(InitRow, AccAcc)
                 end, Acc, lists:seq(1, ?NR_SAMPLES));
-fold_init_rows(modules, Fun, Acc) ->
+fold_init_rows(modules, Fun, Acc,_) ->
     lists:foldl(fun({Mod, Path}, AccAcc) ->
                         InitRow = #{module => Mod, path => Path},
                         Fun(InitRow, AccAcc)


### PR DESCRIPTION
In this case doing a query with a complete subscriber id is optimized
to do a lookup instead of folding over all queues.

TODO: Think about how to test this. Think about how to generalize this. Think about if these dnf-hints already applies to other situations.