### PR TITLE
Do not log peername failure caused by disconnect

### DIFF
--- a/apps/vmq_server/src/vmq_ranch.erl
+++ b/apps/vmq_server/src/vmq_ranch.erl
@@ -82,6 +82,10 @@ init(Ref, Parent, Socket, Transport, Opts) ->
                      fsm_mod=FsmMod,
                      proto_tag=Transport:messages(),
                      parent=Parent});
+        {error, enotconn} ->
+            %% If the client already disconnected we don't want to
+            %% know about it - it's not an error.
+            ok;
         {error, Reason} ->
             lager:debug("could not get socket peername: ~p", [Reason]),
             %% It's not really "ok", but there's no reason for the

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Not yet released
+
+- Do not log getting a client peername failed because the client already
+  disconnected.
+
 ## VERNEMQ 1.2.1
 
 - Upgrade MongoDB driver.


### PR DESCRIPTION
Heart beats / health checks from load balancers like HAProxy connects and disconnects before we do the peername check which fails and therefore spam the log files if the log-level is debug. We shouldn't really log anything in the case the client already disconnected as that is a normal case.