### PR TITLE
Do not resolve hostname when retrieving peer_host

### DIFF
--- a/apps/vmq_server/src/vmq_mqtt_fsm.erl
+++ b/apps/vmq_server/src/vmq_mqtt_fsm.erl
@@ -1135,11 +1135,7 @@ get_info_items([peer_port|Rest], State, Acc) ->
     get_info_items(Rest, State, [{peer_port, PeerPort}|Acc]);
 get_info_items([peer_host|Rest], State, Acc) ->
     {PeerIp, _} = State#state.peer,
-    Host =
-    case inet:gethostbyaddr(PeerIp) of
-        {ok, {hostent, HostName, _, inet, _, _}} ->  HostName;
-        _ -> list_to_binary(inet:ntoa(PeerIp))
-    end,
+    Host = list_to_binary(inet:ntoa(PeerIp)),
     get_info_items(Rest, State, [{peer_host, Host}|Acc]);
 get_info_items([protocol|Rest], State, Acc) ->
     get_info_items(Rest, State, [{protocol, State#state.proto_ver}|Acc]);

--- a/apps/vmq_server/test/vmq_info_SUITE.erl
+++ b/apps/vmq_server/test/vmq_info_SUITE.erl
@@ -93,7 +93,7 @@ filtering_works(_Config) ->
     [#{client_id := <<"vmq-info-client">>, peer_host := PeerHost}] =
         execute(["vmq-admin", "session", "show", "--client_id", "--peer_host"]),
     [#{client_id := <<"vmq-info-client">>, peer_host := PeerHost}] =
-        execute(["vmq-admin", "session", "show", "--peer_host=" ++ PeerHost]),
+        execute(["vmq-admin", "session", "show", "--peer_host=" ++ binary_to_list(PeerHost)]),
 
     [#{client_id := <<"vmq-info-client">>, peer_port := PeerPort}] =
         execute(["vmq-admin", "session", "show", "--client_id", "--peer_port"]),

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Not yet released
+
+- Do not resolve host names when including peer host in an `vmq-admin session
+  show` query as this can lead to a timeout.
+
 ## VERNEMQ 1.2.2
 
 - Fixed a number issues when filtering `vmq-admin session show` results. Note


### PR DESCRIPTION
Fix for #542 