### PR TITLE
Fix webhooks termination crash

### DIFF
--- a/apps/vmq_webhooks/src/vmq_webhooks_plugin.erl
+++ b/apps/vmq_webhooks/src/vmq_webhooks_plugin.erl
@@ -205,8 +205,8 @@ handle_info(_Info, State) ->
 %%--------------------------------------------------------------------
 terminate(_Reason, _State) ->
     {_Hooks, Vals} = lists:unzip(all_hooks()),
-    {Endpoints, _Opts} = lists:unzip(Vals),
-    [ hackney_pool:stop_pool(E) || {E,_} <- lists:usort(lists:flatten(Endpoints)) ],
+    {Endpoints, _Opts} = lists:unzip(lists:flatten(Vals)),
+    [ hackney_pool:stop_pool(E) || {E,_} <- lists:usort(Endpoints) ],
     ok.
 
 %%--------------------------------------------------------------------

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,8 @@
 
 ## Not yet released
 
+- Fix crash in cleanup of the `vmq_webhooks` plugin when the plugin is being
+  stopped or the broker is shutting down (#556).
 - Fix incorrect format strings in `vmq_reg_sup` log statements.
 - Add missing argument to HTTP module configuration log statement.
 - Do not resolve host names when including peer host in an `vmq-admin session


### PR DESCRIPTION
When shutting down the webhooks application it was attempted to stop
the hackney pools for all the endpoints, but there was a bug in the
code retrieving the endpoints causing a crash.

Fixes #556 