### PR TITLE
Find number of sessions in constant time rather than linear time

### DIFF
--- a/apps/vmq_server/src/vmq_queue.erl
+++ b/apps/vmq_server/src/vmq_queue.erl
@@ -779,7 +779,7 @@ insert(MsgOrRef, #state{id=SId, deliver_mode=fanout, sessions=Sessions} = State)
 
 insert(MsgOrRef, #state{id=SId, deliver_mode=balance, sessions=Sessions} = State) ->
     Pids = maps:keys(Sessions),
-    RandomPid = lists:nth(rnd:uniform(length(Pids)), Pids),
+    RandomPid = lists:nth(rnd:uniform(maps:size(Sessions)), Pids),
     RandomSession = maps:get(RandomPid, Sessions),
     {UpdatedSession, _} = session_insert(SId, RandomSession, MsgOrRef),
     State#state{sessions=maps:update(RandomPid, UpdatedSession, Sessions)}.

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ## Not yet released
 
+- Minor opmizations.
 - Fix issue in the queue initialization introduced in VerneMQ 1.2.2 which meant
   offline messages were not being read into the queue process after a node
   restart. Added tests to prevent this issue from occurring again.


### PR DESCRIPTION
just stumbled across this one which seems like a no-brainer. Micro-tested in the shell and could easily measure the difference for maps/lists of just 100 elements. 