### PR TITLE
Strengthen check verifying if a remote node is available

### DIFF
--- a/apps/vmq_server/src/vmq_cluster.erl
+++ b/apps/vmq_server/src/vmq_cluster.erl
@@ -167,7 +167,10 @@ check_ready([Node|Rest], Acc) ->
                        _ -> false
                    end,
     ok = vmq_cluster_node_sup:ensure_cluster_node(Node),
-    check_ready(Rest, [{Node, IsReady}|Acc]);
+    %% We should only say we're ready if we've established a
+    %% connection to the remote node.
+    IsReady1 = IsReady andalso vmq_cluster_node_sup:is_reachable(Node),
+    check_ready(Rest, [{Node, IsReady1}|Acc]);
 check_ready([], Acc) ->
     ClusterReady =
     case lists:keyfind(false, 2, Acc) of

--- a/apps/vmq_server/src/vmq_cluster_node_sup.erl
+++ b/apps/vmq_server/src/vmq_cluster_node_sup.erl
@@ -20,7 +20,8 @@
 -export([start_link/0,
          ensure_cluster_node/1,
          get_cluster_node/1,
-         del_cluster_node/1]).
+         del_cluster_node/1,
+         is_reachable/1]).
 
 %% Supervisor callbacks
 -export([init/1]).
@@ -77,6 +78,16 @@ get_cluster_node(Node) ->
             get_cluster_node(Node);
         {_, Pid, _, _} when is_pid(Pid) ->
             {ok, Pid}
+    end.
+
+is_reachable(Node) when Node == node() ->
+    true;
+is_reachable(Node) ->
+    case get_cluster_node(Node) of
+        {ok, Pid} when is_pid(Pid) ->
+            vmq_cluster_node:is_reachable(Pid);
+        _ ->
+            false
     end.
 
 %%%===================================================================

--- a/apps/vmq_server/test/vmq_cluster_netsplit_SUITE.erl
+++ b/apps/vmq_server/test/vmq_cluster_netsplit_SUITE.erl
@@ -230,17 +230,7 @@ helper_pub_qos1(ClientId, Publish, Port) ->
     gen_tcp:close(Socket).
 
 ensure_cluster(Config) ->
-    [{Node1, _}|OtherNodes] = Nodes = proplists:get_value(nodes, Config),
-    [begin
-         {ok, _} = rpc:call(Node, vmq_server_cmd, node_join, [Node1])
-     end || {Node, _} <- OtherNodes],
-    {NodeNames, _} = lists:unzip(Nodes),
-    Expected = lists:sort(NodeNames),
-    ok = vmq_cluster_test_utils:wait_until_joined(NodeNames, Expected),
-    [?assertEqual({Node, Expected}, {Node,
-                                     lists:sort(vmq_cluster_test_utils:get_cluster_members(Node))})
-     || Node <- NodeNames],
-    ok.
+    vmq_cluster_test_utils:ensure_cluster(Config).
 
 wait_until_converged(Nodes, Fun, ExpectedReturn) ->
     {NodeNames, _} = lists:unzip(Nodes),

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,12 @@
 
 ## Not yet released
 
+- Strengthen check verifying if a remote node is available or not. The new check
+  verifies that a data connection to the remote node has been established, in
+  addition to the current check which verifies that a specific process is running
+  on the remote node. This new check will make it more visible if, for instance,
+  the IP an port configured via `listener.vmq.clustering` is not reachable or a
+  listener was not able to be started.
 - Fix issue preventing the proxy_protocol setting (`listener.tcp.proxy_protocol
   = on`) being inherited by specific listeners (#516).
 - Remove shared subscriptions backwards compatibility code. Introducing shared
@@ -13,7 +19,7 @@
 - Remove time and randomness related dependencies for backwards compatibility
   for OTP 17. These are no longer required as OTP 17 support was removed before
   VerneMQ 1.0.
-- Minor opmizations.
+- Minor optimizations.
 - Fix issue in the queue initialization introduced in VerneMQ 1.2.2 which meant
   offline messages were not being read into the queue process after a node
   restart. Added tests to prevent this issue from occurring again.


### PR DESCRIPTION
This should make it more visible if the cluster configuration is
wrong or if there's a partial netsplit (only specific ports etc).

My initial thought here was that it's annoying that if for some reason the clusters cannot connect (`listener.vmq.clustering`) but the erlang distribution works, then `vmq-admin cluster show` would report true. That makes it hard for people to understand that something is wrong as it's only otherwise written into the logs.
 
Should this be for 1.3.0? It's not strictly a bugfix...
  