### PR TITLE
Make `use_identity_as_username` work for WSS sockets

### DIFF
--- a/apps/vmq_server/src/vmq_ranch_config.erl
+++ b/apps/vmq_server/src/vmq_ranch_config.erl
@@ -223,7 +223,7 @@ protocol_opts(vmq_ranch, _, Opts) -> default_session_opts(Opts);
 protocol_opts(cowboy_protocol, Type, Opts)
   when (Type == mqttws) or (Type == mqttwss) ->
     Dispatch = cowboy_router:compile(
-                 [{'_', [{"/mqtt", vmq_websocket, [default_session_opts(Opts)]}]}
+                 [{'_', [{"/mqtt", vmq_websocket, default_session_opts(Opts)}]}
                  ]),
     [{env, [{dispatch, Dispatch}]}];
 protocol_opts(cowboy_protocol, _, Opts) ->

--- a/changelog.md
+++ b/changelog.md
@@ -20,6 +20,8 @@
   the original client received the message, but the acknowledgement was lost.
 - Fix typo in configuration name `plumtree.outstandind_limit` should be
   `plumtree.outstanding_limit`.
+- Fix bug preventing `use_identity_as_username` from working on WSS sockets
+  (#563).
 
 ## VerneMQ 1.2.3
 


### PR DESCRIPTION
So, here's a quick PR making `use_identity_as_username` work for WSS sockets. This functionality simply wasn't yet implemented

1. There seemed to be a bug in the call to `cowboy_router:compile/1`, the `default_session_opts(Opts)` were wrapped in one list too many.
2. I'm using a private cowboy function (`cowboy_req:get/2`) to get at the socket: https://github.com/erlio/vernemq/compare/master...larshesel:poc-support-identity-as-username-on-wss?expand=1#diff-2902773e8a6f725fa897618b64f0c938R60
3. I'm not completely sure if I'm supposed to use the `Type` like this: https://github.com/erlio/vernemq/compare/master...larshesel:poc-support-identity-as-username-on-wss?expand=1#diff-2902773e8a6f725fa897618b64f0c938R53
4. The `proxy_protocol` feature will not be working - but I guess it'd be extremely strange to if you have a load balancer terminating TLS and want to forward stuff to a websocket instead of a tcp mqtt listener.

This PR was made to address #563 

Is this a bug (1.2.4) or a feature we hadn't implemented (1.3.0)?