### PR TITLE
Handle system messages in `vmq_cluster_node` processes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -20,6 +20,8 @@
   the original client received the message, but the acknowledgement was lost.
 - Fix typo in configuration name `plumtree.outstandind_limit` should be
   `plumtree.outstanding_limit`.
+- Make the `vmq_cluster_node` processes able to handle system messages to make
+  it easier inspect the process behaviour at run-time.
 - Fix bug preventing `use_identity_as_username` from working on WSS sockets
   (#563).
 


### PR DESCRIPTION
Noted while debugging an issue that the `vmq_cluster_node` processes doesn't handle system messages (`sys:get_state/1`).

I guess we should also correctly implement the `system_code_change/4` call at some point if we want the process to be upgradable. Actually I'm not really sure that's needed... I should look further into what is required to upgrade special processes.