### PR TITLE
Add timeout when enqueueing remotely

### DIFF
--- a/apps/vmq_server/priv/vmq_server.schema
+++ b/apps/vmq_server/priv/vmq_server.schema
@@ -269,6 +269,14 @@
                                                                                             {datatype, integer},
                                                                                             hidden
                                                                                            ]}.
+
+%% @doc specifies the timeout for enqueing something in a queue on a remote node.
+{mapping, "remote_enqueue_timeout", "vmq_server.remote_enqueue_timeout", [
+                                                                          {default, 5000},
+                                                                          {datatype, integer},
+                                                                          hidden
+                                                                         ]}.
+
 %% @doc specifies the modules that should be evaluated when setting up the cowboy routes
 {mapping, "http_modules", "vmq_server.http_modules", [
                                                       {default, "[vmq_metrics_http,vmq_http_mgmt_api]"},
@@ -1252,6 +1260,21 @@
                                                                                   {default, prefer_local},
                                                                                   {datatype, atom}
                                                                                  ]}.
+
+%% @doc What action should be taken if enqueing a shared subscriber
+%% message to a subscriber on a remote node fails due to a timeout. If
+%% this happens it is not certain if the remote subscriber has
+%% received the message or not. If the remote subscriber has not
+%% received the message and the action is `ignore`, the message will
+%% be lost. If the remote subscriber did receive the message and the
+%% action is `requeue` and a subscriber successfully accepts the
+%% message, the message will be delivered to both shared subscribers.
+{mapping, "shared_subscription_timeout_action",
+ "vmq_server.shared_subscription_timeout_action", [
+                                                   {default, ignore},
+                                                   {datatype, {enum, [ignore, requeue]}},
+                                                   hidden
+                                                  ]}.
 
 %% @doc plugins.<plugin> enables/disables a plugin.
 %%

--- a/apps/vmq_server/src/vmq_cluster.erl
+++ b/apps/vmq_server/src/vmq_cluster.erl
@@ -33,7 +33,7 @@
          if_ready/2,
          if_ready/3,
          publish/2,
-         remote_enqueue/2]).
+         remote_enqueue/3]).
 
 -define(SERVER, ?MODULE).
 -define(VMQ_CLUSTER_STATUS, vmq_status). %% table is owned by vmq_cluster_mon
@@ -92,16 +92,17 @@ publish(Node, Msg) ->
             vmq_cluster_node:publish(Pid, Msg)
     end.
 
--spec remote_enqueue(node(), Term)
+-spec remote_enqueue(node(), Term, BufferIfUnreachable)
         -> ok | {error, term()}
-        when Term::{enqueue_many, subscriber_id(), Msgs::term(), Opts::map()}
-                 | {enqueue, Queue::term(), Msgs::term()}.
-remote_enqueue(Node, Term) ->
+        when Term :: {enqueue_many, subscriber_id(), Msgs::term(), Opts::map()}
+                   | {enqueue, Queue::term(), Msgs::term()},
+             BufferIfUnreachable :: boolean().
+remote_enqueue(Node, Term, BufferIfUnreachable) ->
     case vmq_cluster_node_sup:get_cluster_node(Node) of
         {error, not_found} ->
             {error, not_found};
         {ok, Pid} ->
-            vmq_cluster_node:enqueue(Pid, Term)
+            vmq_cluster_node:enqueue(Pid, Term, BufferIfUnreachable)
     end.
 
 %%%===================================================================

--- a/apps/vmq_server/src/vmq_config_cli.erl
+++ b/apps/vmq_server/src/vmq_config_cli.erl
@@ -49,7 +49,8 @@ register_config_() ->
      "graphite_host",
      "graphite_port",
      "graphite_interval",
-     "shared_subscription_policy"
+     "shared_subscription_policy",
+     "remote_enqueue_timeout"
     ],
     _ = [clique:register_config([Key], fun register_config_callback/3)
          || Key <- ConfigKeys],

--- a/apps/vmq_server/src/vmq_server.app.src
+++ b/apps/vmq_server/src/vmq_server.app.src
@@ -81,7 +81,11 @@
       ]},
       {http_modules, [vmq_metrics_http, vmq_http_mgmt_api]},
       {outgoing_clustering_buffer_size, 10000},
+      {remote_enqueue_timeout, 5000},
       {outgoing_connect_opts, []},
+      {shared_subscription_policy, prefer_local},
+      {shared_subscription_timeout_action, ignore},
+
       {tcp_listen_options, [
             {nodelay, true},
             {linger, {true, 0}}, 

--- a/apps/vmq_server/src/vmq_shared_subscriptions.erl
+++ b/apps/vmq_server/src/vmq_shared_subscriptions.erl
@@ -85,7 +85,7 @@ publish_(Msg, {Node, SubscriberId, QoS}, QState) when Node == node() ->
     end;
 publish_(Msg, {Node, SubscriberId, QoS}, QState) ->
     Term = {enqueue_many, SubscriberId, [{deliver, QoS, Msg}], #{states => [QState]}},
-    vmq_cluster:remote_enqueue(Node, Term).
+    vmq_cluster:remote_enqueue(Node, Term, true).
 
 filter_subscribers(Subscribers, random) ->
     Subscribers;

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,22 @@
 
 ## Not yet released
 
+- Fix issue where enqueuing data to a queue on a remote cluster node could cause
+  the calling process to be blocked for a long time in case of the remote
+  cluster node being overloaded or if a net-split has occurred.
+  
+  This issue can occur while delivering a shared subscriber message to a remote
+  subscriber in the cluster (blocking the publishing client) or when migrating
+  queue data to to another node in the cluster. In the case of shared
+  subscribers a new (hidden) configuration parameter
+  (`shared_subscription_timeout_action`) has been added which decides which
+  action to take if enqueuing on a remote note times out waiting for the
+  receiving node to acknowledge the message. The possibilities are to either
+  `ignore` the timeout or `requeue` the message.  Ignoring the timeout can
+  potentially lead to losing the message if the message was still in flight
+  between the two nodes and the connection was lost due to a
+  net-split. Requeueing may lead to the same message being delivered twice if
+  the original client received the message, but the acknowledgement was lost.
 - Fix typo in configuration name `plumtree.outstandind_limit` should be
   `plumtree.outstanding_limit`.
 


### PR DESCRIPTION
This timeout ensures that callers of the
`vmq_cluster:remote_enqueue/3` function will not block indefinitely if
the acknowledgement message is lost due to a slow remote node or a
netsplit.

TODO:
 - [x]  still need to manually test it works
 - [x] add actual tests for this case
 - [x] manually tested that the client doesn't terminate if it receives either `{reference(), ok}` or `{reference(), {error, cant_remote_enqueue}}`