### PR TITLE
Allow the lwt fields to be undefined in the connect frame spec

### DIFF
--- a/apps/vmq_commons/include/vmq_types.hrl
+++ b/apps/vmq_commons/include/vmq_types.hrl
@@ -27,10 +27,10 @@
           clean_session     :: flag(),
           keep_alive        :: non_neg_integer(),
           client_id         :: client_id(),
-          will_retain       :: flag(),
-          will_qos          :: qos(),
-          will_topic        :: topic(),
-          will_msg          :: payload()
+          will_retain       :: flag() | undefined,
+          will_qos          :: qos() | undefined,
+          will_topic        :: topic() | undefined,
+          will_msg          :: payload() | undefined
          }).
 -type mqtt_connect()        :: #mqtt_connect{}.
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Not yet released (VerneMQ 1.4.0)
+
+- Fix some Dialyzer issues.
+
 ## VerneMQ 1.3.0
 
 - Add `proxy_protocol_use_cn_as_username` feature which for `proxy_protocol`


### PR DESCRIPTION
All the retained fields can be defined or undefined as they are an
optional part of the connect frame.