### PR TITLE
Disable flaky test

### DIFF
--- a/apps/vmq_diversity/test/vmq_diversity_script_balancer_SUITE.erl
+++ b/apps/vmq_diversity/test/vmq_diversity_script_balancer_SUITE.erl
@@ -29,7 +29,10 @@ end_per_testcase(_, Config) ->
     Config.
 
 all() ->
-    [load_balancing_test_simple].
+    [
+     %% disabled as travis routinely fails this test for some reason.
+     %%load_balancing_test_simple
+    ].
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%% Actual Tests


### PR DESCRIPTION
The vmq_diversity load balancer tests routinely fails on travis-ci but
never locally. Disabling it for now.