### PR TITLE
Generalize connect suite

### DIFF
--- a/apps/vmq_server/src/vmq_server_cmd.erl
+++ b/apps/vmq_server/src/vmq_server_cmd.erl
@@ -60,18 +60,18 @@ listener_stop(Port, Address) ->
     listener_stop(Port, Address, false).
 listener_stop(Port, Address, false) when is_integer(Port) and is_list(Address) ->
     vmq_server_cli:command(["vmq-admin", "listener", "stop",
-                            "port", integer_to_list(Port),
-                            "address", Address], false);
+                            "port=" ++ integer_to_list(Port),
+                            "address=" ++ Address], false);
 listener_stop(Port, Address, true) when is_integer(Port) and is_list(Address) ->
     vmq_server_cli:command(["vmq-admin", "listener", "stop",
-                            "port", integer_to_list(Port),
-                            "address", Address,
+                            "port=" ++ integer_to_list(Port),
+                            "address=" ++ Address,
                             "--kill_sessions"], false).
 
 listener_delete(Port, Address) when is_integer(Port) and is_list(Address) ->
     vmq_server_cli:command(["vmq-admin", "listener", "delete",
-                            "port", integer_to_list(Port),
-                            "address", Address], false).
+                            "port=" ++ integer_to_list(Port),
+                            "address=" ++ Address], false).
 
 metrics() ->
     vmq_server_cli:command(["vmq-admin", "metrics", "show"], false).

--- a/apps/vmq_server/test/vmq_connect_SUITE.erl
+++ b/apps/vmq_server/test/vmq_connect_SUITE.erl
@@ -1,65 +1,65 @@
 -module(vmq_connect_SUITE).
--export([
-         %% suite/0,
-         init_per_suite/1,
-         end_per_suite/1,
-         init_per_testcase/2,
-         end_per_testcase/2,
-         all/0
-        ]).
 
--export([anon_denied_test/1,
-         anon_success_test/1,
-         invalid_id_0_test/1,
-         invalid_id_0_311_test/1,
-         invalid_id_missing_test/1,
-         invalid_id_24_test/1,
-         invalid_protonum_test/1,
-         uname_no_password_denied_test/1,
-         uname_password_denied_test/1,
-         uname_password_success_test/1,
-         change_subscriber_id_test/1]).
-
--export([hook_empty_client_id_proto_4/5,
-         hook_uname_no_password_denied/5,
-         hook_uname_password_denied/5,
-         hook_uname_password_success/5,
-         hook_change_subscriber_id/5,
-         hook_on_register_changed_subscriber_id/3]).
+-compile(export_all).
+-compile(nowarn_export_all).
 
 %% ===================================================================
 %% common_test callbacks
 %% ===================================================================
 init_per_suite(_Config) ->
     cover:start(),
+    vmq_test_utils:setup(),
     _Config.
 
 end_per_suite(_Config) ->
+    vmq_test_utils:teardown(),
     _Config.
 
+init_per_group(mqtt, Config) ->
+    Port = 1888,
+    Address = "127.0.0.1",
+    Opts = [],
+    vmq_server_cmd:listener_start(Port, Address, Opts),
+    [{address, Address},{port, Port},{opts, Opts}|Config].
+
+end_per_group(mqtt, Config) ->
+    Port = proplists:get_value(port, Config),
+    Address = proplists:get_value(address, Config),
+    vmq_server_cmd:listener_stop(Port, Address, false),
+    ok.
+
 init_per_testcase(_Case, Config) ->
-    vmq_test_utils:setup(),
+    %% reset config before each test
     vmq_server_cmd:set_config(allow_anonymous, false),
     vmq_server_cmd:set_config(max_client_id_size, 23),
-    vmq_server_cmd:listener_start(1888, []),
+    vmq_config:configure_node(),
     Config.
 
 end_per_testcase(_, Config) ->
-    vmq_test_utils:teardown(),
     Config.
 
 all() ->
-    [anon_denied_test,
-     anon_success_test,
-     invalid_id_0_test,
-     invalid_id_0_311_test,
-     invalid_id_missing_test,
-     invalid_id_24_test,
-     invalid_protonum_test,
-     uname_no_password_denied_test,
-     uname_password_denied_test,
-     uname_password_success_test,
-     change_subscriber_id_test].
+    [
+     {group, mqtt}
+    ].
+
+groups() ->
+    Tests = 
+        [anon_denied_test,
+         anon_success_test,
+         invalid_id_0_test,
+         invalid_id_0_311_test,
+         invalid_id_missing_test,
+         invalid_id_24_test,
+         invalid_protonum_test,
+         uname_no_password_denied_test,
+         uname_password_denied_test,
+         uname_password_success_test,
+         change_subscriber_id_test
+        ],
+    [
+     {mqtt, [], Tests}
+    ].
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%% Actual Tests
@@ -88,10 +88,11 @@ invalid_id_0_test(_) ->
 invalid_id_0_311_test(_) ->
     Connect = packet:gen_connect(empty, [{keepalive,10},{proto_ver,4}]),
     Connack = packet:gen_connack(0),
-    vmq_plugin_mgr:enable_module_plugin(
+    vmq_server_cmd:set_config(allow_anonymous, false),
+    ok = vmq_plugin_mgr:enable_module_plugin(
       auth_on_register, ?MODULE, hook_empty_client_id_proto_4, 5),
     {ok, Socket} = packet:do_client_connect(Connect, Connack, []),
-    vmq_plugin_mgr:disable_module_plugin(
+    ok = vmq_plugin_mgr:disable_module_plugin(
       auth_on_register, ?MODULE, hook_empty_client_id_proto_4, 5),
     ok = gen_tcp:close(Socket).
 
@@ -139,10 +140,10 @@ uname_password_success_test(_) ->
     Connect = packet:gen_connect("connect-uname-pwd-test", [{keepalive,10}, {username, "user"},
                                                             {password, "password9"}]),
     Connack = packet:gen_connack(0),
-    vmq_plugin_mgr:enable_module_plugin(
+    ok = vmq_plugin_mgr:enable_module_plugin(
       auth_on_register, ?MODULE, hook_uname_password_success, 5),
     {ok, Socket} = packet:do_client_connect(Connect, Connack, []),
-    vmq_plugin_mgr:disable_module_plugin(
+    ok = vmq_plugin_mgr:disable_module_plugin(
       auth_on_register, ?MODULE, hook_uname_password_success, 5),
     ok = gen_tcp:close(Socket).
 
@@ -151,14 +152,14 @@ change_subscriber_id_test(_) ->
                                  [{keepalive,10}, {username, "whatever"},
                                   {password, "whatever"}]),
     Connack = packet:gen_connack(0),
-    vmq_plugin_mgr:enable_module_plugin(
+    ok = vmq_plugin_mgr:enable_module_plugin(
       auth_on_register, ?MODULE, hook_change_subscriber_id, 5),
-    vmq_plugin_mgr:enable_module_plugin(
+    ok = vmq_plugin_mgr:enable_module_plugin(
       on_register, ?MODULE, hook_on_register_changed_subscriber_id, 3),
     {ok, Socket} = packet:do_client_connect(Connect, Connack, []),
-    vmq_plugin_mgr:disable_module_plugin(
-      on_register, ?MODULE, hook_on_register_changed_subscriber_id, 5),
-    vmq_plugin_mgr:disable_module_plugin(
+    ok = vmq_plugin_mgr:disable_module_plugin(
+      on_register, ?MODULE, hook_on_register_changed_subscriber_id, 3),
+    ok = vmq_plugin_mgr:disable_module_plugin(
       auth_on_register, ?MODULE, hook_change_subscriber_id, 5),
     ok = gen_tcp:close(Socket).
 

--- a/apps/vmq_server/test/vmq_connect_SUITE.erl
+++ b/apps/vmq_server/test/vmq_connect_SUITE.erl
@@ -16,16 +16,17 @@ end_per_suite(_Config) ->
     _Config.
 
 init_per_group(mqtt, Config) ->
-    Port = 1888,
-    Address = "127.0.0.1",
-    Opts = [],
-    vmq_server_cmd:listener_start(Port, Address, Opts),
-    [{address, Address},{port, Port},{opts, Opts}|Config].
+    Config1 = [{type, tcp},{port, 1888}, {address, "127.0.0.1"}|Config],
+    start_listener(Config1);
+init_per_group(mqtts, Config) ->
+    Config1 = [{type, tcp},{port, 1889}, {address, "127.0.0.1"}|Config],
+    start_listener(Config1);
+init_per_group(mqttws, Config) ->
+    Config1 = [{type, ws},{port, 1890}, {address, "127.0.0.1"}|Config],
+    start_listener(Config1).
 
-end_per_group(mqtt, Config) ->
-    Port = proplists:get_value(port, Config),
-    Address = proplists:get_value(address, Config),
-    vmq_server_cmd:listener_stop(Port, Address, false),
+end_per_group(_Group, Config) ->
+    stop_listener(Config),
     ok.
 
 init_per_testcase(_Case, Config) ->
@@ -40,7 +41,9 @@ end_per_testcase(_, Config) ->
 
 all() ->
     [
-     {group, mqtt}
+     {group, mqtt},
+     {group, mqtts},
+     {group, mqttws}
     ].
 
 groups() ->
@@ -58,96 +61,97 @@ groups() ->
          change_subscriber_id_test
         ],
     [
-     {mqtt, [], Tests}
+     {mqtt, [shuffle,sequence], Tests},
+     {mqtts, [], Tests},
+     {mqttws, [], Tests}
     ].
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%% Actual Tests
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-anon_denied_test(_) ->
+anon_denied_test(Config) ->
     Connect = packet:gen_connect("connect-anon-test", [{keepalive,10}]),
     Connack = packet:gen_connack(5),
-    {ok, Socket} = packet:do_client_connect(Connect, Connack, []),
-    ok = gen_tcp:close(Socket).
+    {ok, Socket} = packet:do_client_connect(Connect, Connack, conn_opts(Config)),
+    ok = close(Socket, Config).
 
-anon_success_test(_) ->
+anon_success_test(Config) ->
     vmq_server_cmd:set_config(allow_anonymous, true),
     vmq_config:configure_node(),
     %% allow_anonymous is proxied through vmq_config.erl
     Connect = packet:gen_connect("connect-success-test", [{keepalive,10}]),
     Connack = packet:gen_connack(0),
-    {ok, Socket} = packet:do_client_connect(Connect, Connack, []),
-    ok = gen_tcp:close(Socket).
+    {ok, Socket} = packet:do_client_connect(Connect, Connack, conn_opts(Config)),
+    ok = close(Socket, Config).
 
-invalid_id_0_test(_) ->
+invalid_id_0_test(Config) ->
     Connect = packet:gen_connect(empty, [{keepalive,10}]),
     Connack = packet:gen_connack(2),
-    {ok, Socket} = packet:do_client_connect(Connect, Connack, []),
-    ok = gen_tcp:close(Socket).
+    {ok, Socket} = packet:do_client_connect(Connect, Connack, conn_opts(Config)),
+    ok = close(Socket, Config).
 
-invalid_id_0_311_test(_) ->
+invalid_id_0_311_test(Config) ->
     Connect = packet:gen_connect(empty, [{keepalive,10},{proto_ver,4}]),
     Connack = packet:gen_connack(0),
-    vmq_server_cmd:set_config(allow_anonymous, false),
     ok = vmq_plugin_mgr:enable_module_plugin(
       auth_on_register, ?MODULE, hook_empty_client_id_proto_4, 5),
-    {ok, Socket} = packet:do_client_connect(Connect, Connack, []),
+    {ok, Socket} = packet:do_client_connect(Connect, Connack, conn_opts(Config)),
     ok = vmq_plugin_mgr:disable_module_plugin(
       auth_on_register, ?MODULE, hook_empty_client_id_proto_4, 5),
-    ok = gen_tcp:close(Socket).
+    ok = close(Socket, Config).
 
-invalid_id_missing_test(_) ->
+invalid_id_missing_test(Config) ->
     Connect = packet:gen_connect(undefined, [{keepalive,10}]),
-    {error, closed} = packet:do_client_connect(Connect, <<>>, []).
+    {error, closed} = packet:do_client_connect(Connect, <<>>, conn_opts(Config)).
 
-invalid_id_24_test(_) ->
+invalid_id_24_test(Config) ->
     Connect = packet:gen_connect("connect-invalid-id-test-", [{keepalive,10}]),
     Connack = packet:gen_connack(2), %% client id longer than 23 Characters
-    {ok, Socket} = packet:do_client_connect(Connect, Connack, []),
-    ok = gen_tcp:close(Socket).
+    {ok, Socket} = packet:do_client_connect(Connect, Connack, conn_opts(Config)),
+    ok = close(Socket, Config).
 
-invalid_protonum_test(_) ->
+invalid_protonum_test(Config) ->
     %% mosq_test.gen_connect("test", keepalive=10, proto_ver=0)
     Connect = <<16#10,16#12,16#00,16#06,16#4d,16#51,16#49,16#73,
                 16#64,16#70,16#00,16#02,16#00,16#0a,16#00,16#04,
                 16#74,16#65,16#73,16#74>>,
     Connack = packet:gen_connack(1),
-    {ok, Socket} = packet:do_client_connect(Connect, Connack, []),
-    ok = gen_tcp:close(Socket).
+    {ok, Socket} = packet:do_client_connect(Connect, Connack, conn_opts(Config)),
+    ok = close(Socket, Config).
 
-uname_no_password_denied_test(_) ->
+uname_no_password_denied_test(Config) ->
     Connect = packet:gen_connect("connect-uname-test-", [{keepalive,10}, {username, "user"}]),
     Connack = packet:gen_connack(4),
     ok = vmq_plugin_mgr:enable_module_plugin(
       auth_on_register, ?MODULE, hook_uname_no_password_denied, 5),
-    {ok, Socket} = packet:do_client_connect(Connect, Connack, []),
+    {ok, Socket} = packet:do_client_connect(Connect, Connack, conn_opts(Config)),
     ok = vmq_plugin_mgr:disable_module_plugin(
       auth_on_register, ?MODULE, hook_uname_no_password_denied, 5),
-    ok = gen_tcp:close(Socket).
+    ok = close(Socket, Config).
 
-uname_password_denied_test(_) ->
+uname_password_denied_test(Config) ->
     Connect = packet:gen_connect("connect-uname-pwd-test", [{keepalive,10}, {username, "user"},
                                                             {password, "password9"}]),
     Connack = packet:gen_connack(4),
     ok = vmq_plugin_mgr:enable_module_plugin(
       auth_on_register, ?MODULE, hook_uname_password_denied, 5),
-    {ok, Socket} = packet:do_client_connect(Connect, Connack, []),
+    {ok, Socket} = packet:do_client_connect(Connect, Connack, conn_opts(Config)),
     ok = vmq_plugin_mgr:disable_module_plugin(
       auth_on_register, ?MODULE, hook_uname_password_denied, 5),
-    ok = gen_tcp:close(Socket).
+    ok = close(Socket, Config).
 
-uname_password_success_test(_) ->
+uname_password_success_test(Config) ->
     Connect = packet:gen_connect("connect-uname-pwd-test", [{keepalive,10}, {username, "user"},
                                                             {password, "password9"}]),
     Connack = packet:gen_connack(0),
     ok = vmq_plugin_mgr:enable_module_plugin(
       auth_on_register, ?MODULE, hook_uname_password_success, 5),
-    {ok, Socket} = packet:do_client_connect(Connect, Connack, []),
+    {ok, Socket} = packet:do_client_connect(Connect, Connack, conn_opts(Config)),
     ok = vmq_plugin_mgr:disable_module_plugin(
       auth_on_register, ?MODULE, hook_uname_password_success, 5),
-    ok = gen_tcp:close(Socket).
+    ok = close(Socket, Config).
 
-change_subscriber_id_test(_) ->
+change_subscriber_id_test(Config) ->
     Connect = packet:gen_connect("change-sub-id-test",
                                  [{keepalive,10}, {username, "whatever"},
                                   {password, "whatever"}]),
@@ -156,12 +160,12 @@ change_subscriber_id_test(_) ->
       auth_on_register, ?MODULE, hook_change_subscriber_id, 5),
     ok = vmq_plugin_mgr:enable_module_plugin(
       on_register, ?MODULE, hook_on_register_changed_subscriber_id, 3),
-    {ok, Socket} = packet:do_client_connect(Connect, Connack, []),
+    {ok, Socket} = packet:do_client_connect(Connect, Connack, conn_opts(Config)),
     ok = vmq_plugin_mgr:disable_module_plugin(
       on_register, ?MODULE, hook_on_register_changed_subscriber_id, 3),
     ok = vmq_plugin_mgr:disable_module_plugin(
       auth_on_register, ?MODULE, hook_change_subscriber_id, 5),
-    ok = gen_tcp:close(Socket).
+    ok = close(Socket, Config).
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%% Hooks
@@ -174,3 +178,90 @@ hook_change_subscriber_id(_, {"", <<"change-sub-id-test">>}, _, _, _) ->
     {ok, [{subscriber_id, {"newmp", <<"changed-client-id">>}}]}.
 hook_on_register_changed_subscriber_id(_, {"newmp", <<"changed-client-id">>}, _) ->
     ok.
+
+%% Helpers
+stop_listener(Config) ->
+    Port = proplists:get_value(port, Config),
+    Address = proplists:get_value(address, Config),
+    vmq_server_cmd:listener_stop(Port, Address, false).
+
+
+close(Socket, Config) ->
+    (transport(Config)):close(Socket).
+
+transport(Config) ->
+    case lists:keyfind(type, 1, Config) of
+        {type, tcp} ->
+            gen_tcp;
+        {type, ssl} ->
+            ssl;
+        {type, ws} ->
+            gen_tcp
+    end.
+
+conn_opts(Config) ->
+    {port, Port} = lists:keyfind(port, 1, Config),
+    {address, Address} = lists:keyfind(address, 1, Config),
+    {type, Type} = lists:keyfind(type, 1, Config),
+    TransportOpts =
+        case Type of
+            tcp ->
+                [{transport, gen_tcp}, {conn_opts, []}];
+            ssl ->
+                [{transport, ssl},
+                 {conn_opts, 
+                  [
+                   {cacerts, load_cacerts()}
+                  ]}];
+            ws ->
+                [{transport, vmq_ws_transport}, {conn_opts, []}]
+        end,
+    [{port, Port},{hostname, Address}|TransportOpts].
+
+load_cacerts() ->
+    IntermediateCA = ssl_path("test-signing-ca.crt"),
+    RootCA = ssl_path("test-root-ca.crt"),
+    load_cert(RootCA) ++ load_cert(IntermediateCA).
+
+load_cert(Cert) ->
+    {ok, Bin} = file:read_file(Cert),
+    case filename:extension(Cert) of
+        ".der" ->
+            %% no decoding necessary
+            [Bin];
+        _ ->
+            %% assume PEM otherwise
+            Contents = public_key:pem_decode(Bin),
+            [DER || {Type, DER, Cipher} <-
+                    Contents, Type == 'Certificate',
+                    Cipher == 'not_encrypted']
+    end.
+
+start_listener(Config) ->
+    {port, Port} = lists:keyfind(port, 1, Config),
+    {address, Address} = lists:keyfind(address, 1, Config),
+    {type, Type} = lists:keyfind(type, 1, Config),
+ 
+    Opts1 =
+        case Type of
+            ssl ->
+                [{ssl, true},
+                 {nr_of_acceptors, 5},
+                 {cafile, ssl_path("all-ca.crt")},
+                 {certfile, ssl_path("server.crt")},
+                 {keyfile, ssl_path("server.key")},
+                 {tls_version, "tlsv1.2"}];
+            tcp ->
+                [];
+            ws ->
+                [{websocket,true}]
+        end,
+    {ok, _} = vmq_server_cmd:listener_start(Port, Address, Opts1),
+    [{address, Address},{port, Port},{opts, Opts1}|Config].
+
+ssl_path(File) ->
+    Path = filename:dirname(
+             proplists:get_value(source, ?MODULE:module_info(compile))),
+    filename:join([Path, "ssl", File]).
+
+

--- a/apps/vmq_server/test/vmq_ws_transport.erl
+++ b/apps/vmq_server/test/vmq_ws_transport.erl
@@ -1,0 +1,181 @@
+%% Copyright 2018 Erlio GmbH Basel Switzerland (http://erl.io)
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+-module(vmq_ws_transport).
+
+-export([connect/4,
+         send/2,
+         recv/3,
+         close/1
+        ]).
+
+connect(Host, Port, Opts, Timeout) ->
+    case gen_tcp:connect(Host, Port, Opts, Timeout) of
+        {ok, Socket} ->
+            Hello = [
+                     "GET /mqtt HTTP/1.1\r\n"
+                     "Host: localhost\r\n"
+                     "Connection: Upgrade\r\n"
+                     "Origin: http://localhost\r\n"
+                     "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n"
+                     "Sec-WebSocket-Protocol: mqtt\r\n"
+                     "Sec-WebSocket-Version: 13\r\n"
+                     "Upgrade: websocket\r\n"
+                     "\r\n"],
+            gen_tcp:send(Socket, Hello),
+            {ok, Handshake} = gen_tcp:recv(Socket, 0, 6000),
+            {ok, {http_response, {1, 1}, 101, "Switching Protocols"}, Rest}
+		= erlang:decode_packet(http, Handshake, []),
+            [Headers, <<>>] = do_decode_headers(
+                                erlang:decode_packet(httph, Rest, []), []),
+            {'Connection', "Upgrade"} = lists:keyfind('Connection', 1, Headers),
+            {'Upgrade', "websocket"} = lists:keyfind('Upgrade', 1, Headers),
+            {"sec-websocket-accept", "s3pPLMBiTxaQ9kYGzzhZRbK+xOo="}
+		= lists:keyfind("sec-websocket-accept", 1, Headers),
+            {"sec-websocket-protocol", "mqtt"}
+                = lists:keyfind("sec-websocket-protocol", 1, Headers),
+            {ok, Socket};
+        E ->
+            E
+    end.
+
+send(Socket, Data) ->
+    Mask = rand:uniform(4294967296) - 1,
+    MaskedData = do_mask(Data, Mask, <<>>),
+    EncLen = enc_len(byte_size(MaskedData)),
+    Frame = <<16#82, EncLen/binary, Mask:32, MaskedData/binary>>,
+    gen_tcp:send(Socket, Frame).
+
+recv(Socket, Length, Timeout) when Length > 0 ->
+    %% TODO: handle case when Length =:= 0.
+    %% get any leftovers from last time we received data.
+    Acc = get_and_clear_rest(Socket),
+    %% Need to keep receiving until we have Length MQTT data or
+    %% Timeout time is elapsed.
+    receive_data(Socket, Length, Timeout, 0, Acc).
+
+close(Socket) ->
+    gen_tcp:close(Socket).
+
+%%% Internal functions
+receive_data(Socket, _Length, Timeout, Elapsed, Acc) when Elapsed > Timeout ->
+    store_rest(Socket, Acc),
+    {error, timeout};
+receive_data(Socket, Length, Timeout, Elapsed, Acc) ->
+    case gen_tcp:recv(Socket, 0, 5) of
+        {ok, RecvData} ->
+            Data = <<Acc/binary, RecvData/binary>>,
+            case parse(Data) of
+                {close, <<ParsedData:Length/binary>>, _Rest} ->
+                    gen_tcp:close(Socket),
+                    {ok, ParsedData};
+                {close, <<>>, _Rest} ->
+                    gen_tcp:close(Socket),
+                    {error, closed};
+                {ok, <<ParsedData:Length/binary>>,  Rest} ->
+                    store_rest(Socket, Rest),
+                    {ok, ParsedData};
+                more ->
+                    receive_data(Socket, Length, Timeout, Elapsed, Data)
+            end;
+        {error, timeout} ->
+            receive_data(Socket, Length, Timeout, Elapsed + 5, Acc);
+        {error, _} = E -> E
+    end.
+
+parse(Data) ->
+    case parse(Data, []) of
+        {[], _Rest} -> more;
+        {Frames, Rest} ->
+            {Action, Data0} = assemble_frames(Frames),
+            {Action, Data0, Rest}
+    end.
+
+parse(<<136,2, 3, 232, Rest/binary>>, Frames) ->
+    parse(Rest, [{close,normal}|Frames]);
+parse(<<1:1, 0:3, 2:4, PayloadData/binary>>, Frames) ->
+    case get_payload(PayloadData) of
+        more ->
+            {lists:reverse(Frames), PayloadData};
+        {Frame, Rest} ->
+            parse(Rest, [{data, Frame}|Frames])
+    end;
+parse(Rest, Frames) ->
+    {lists:reverse(Frames), Rest}.
+
+assemble_frames(Frames) ->
+    assemble_frames(Frames, <<>>).
+
+assemble_frames([], Acc) ->
+    {ok, Acc};
+assemble_frames([{close,normal}|_], Acc) ->
+    {close, Acc};
+assemble_frames([{data, Data}|Tail], Acc) ->
+    assemble_frames(Tail, <<Acc/binary, Data/binary>>).
+
+store_rest(Socket, Rest) ->
+    put({Socket, ws_rest_data}, Rest).
+
+get_and_clear_rest(Socket) ->
+    case get({Socket, ws_rest_data}) of
+        undefined -> <<>>;
+        Data ->
+            put({Socket, ws_rest_data}, undefined),
+            Data
+    end.
+
+
+enc_len(Len) when Len < 126 ->
+    <<1:1, Len:7>>;
+enc_len(Len) when Len < 65536 ->
+    <<1:1, 126:7, Len:16/big>>;
+enc_len(Len) when Len < 18446744073709551616 ->
+    <<1:1, 127:7, Len:64/big>>.
+
+get_payload(<<0:1, 127:7, Len:64/big, Data:Len/binary, Rest/binary>>) ->
+    {Data, Rest};
+get_payload(<<0:1, 126:7, Len:16/big, Data:Len/binary, Rest/binary>>) ->
+    {Data, Rest};
+get_payload(<<0:1, Len:7, Data:Len/binary, Rest/binary>>) ->
+    {Data, Rest};
+get_payload(_) ->
+    more.
+
+
+%% The `do_decode_headers/2` and `do_mask/3` functions were borrowed
+%% from the Cowboy websocket test suite
+%% (https://github.com/ninenines/cowboy).
+do_decode_headers({ok, http_eoh, Rest}, Acc) ->
+	[Acc, Rest];
+do_decode_headers({ok, {http_header, _I, Key, _R, Value}, Rest}, Acc) ->
+	F = fun(S) when is_atom(S) -> S; (S) -> string:to_lower(S) end,
+	do_decode_headers(erlang:decode_packet(httph, Rest, []),
+		[{F(Key), Value}|Acc]).
+
+do_mask(<<>>, _, Acc) ->
+	Acc;
+do_mask(<< O:32, Rest/bits >>, MaskKey, Acc) ->
+	T = O bxor MaskKey,
+	do_mask(Rest, MaskKey, << Acc/binary, T:32 >>);
+do_mask(<< O:24 >>, MaskKey, Acc) ->
+	<< MaskKey2:24, _:8 >> = << MaskKey:32 >>,
+	T = O bxor MaskKey2,
+	<< Acc/binary, T:24 >>;
+do_mask(<< O:16 >>, MaskKey, Acc) ->
+	<< MaskKey2:16, _:16 >> = << MaskKey:32 >>,
+	T = O bxor MaskKey2,
+	<< Acc/binary, T:16 >>;
+do_mask(<< O:8 >>, MaskKey, Acc) ->
+	<< MaskKey2:8, _:24 >> = << MaskKey:32 >>,
+	T = O bxor MaskKey2,
+	<< Acc/binary, T:8 >>.


### PR DESCRIPTION
I also started adding an `mqtts` group, but it didn't turn out as I wanted it. SSL is complex because it has so many different setups.

At least the code below fixes a couple of bugs and makes the connect suite faster by more than 50% (~13 of 23 secs).

To check that tests are truly independent, we could consider setting the `shuffle` property on the group.

Didn't add a changelog entry as I don't consider test-refactoring to be relevant to the users.