### PR TITLE
Generalize reusable fsm functionality

### DIFF
--- a/apps/vmq_server/src/vmq_mqtt_fsm_util.erl
+++ b/apps/vmq_server/src/vmq_mqtt_fsm_util.erl
@@ -1,0 +1,83 @@
+%% Copyright 2018 Erlio GmbH Basel Switzerland (http://erl.io)
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+
+-module(vmq_mqtt_fsm_util).
+-include("vmq_server.hrl").
+
+-export([send/2,
+         send_after/2,
+         msg_ref/0,
+         plugin_receive_loop/2]).
+
+-define(TO_SESSION, to_session_fsm).
+
+-spec msg_ref() -> msg_ref().
+msg_ref() ->
+    GUID =
+    case get(guid) of
+        undefined ->
+            {{node(), self(), erlang:timestamp()}, 0};
+        {S, I} ->
+            {S, I + 1}
+    end,
+    put(guid, GUID),
+    erlang:md5(term_to_binary(GUID)).
+
+-spec send(pid(), any()) -> ok.
+send(SessionPid, Msg) ->
+    SessionPid ! {?TO_SESSION, Msg},
+    ok.
+
+-spec send_after(non_neg_integer(), any()) -> reference().
+send_after(Time, Msg) ->
+    erlang:send_after(Time, self(), {?TO_SESSION, Msg}).
+
+-spec plugin_receive_loop(pid(), atom()) -> no_return().
+plugin_receive_loop(PluginPid, PluginMod) ->
+    receive
+        {?TO_SESSION, {mail, QPid, new_data}} ->
+            vmq_queue:active(QPid),
+            plugin_receive_loop(PluginPid, PluginMod);
+        {?TO_SESSION, {mail, QPid, Msgs, _, _}} ->
+            lists:foreach(fun({deliver, QoS, #vmq_msg{
+                                                routing_key=RoutingKey,
+                                                payload=Payload,
+                                                retain=IsRetain,
+                                                dup=IsDup}}) ->
+                                  PluginPid ! {deliver, RoutingKey,
+                                               Payload,
+                                               QoS,
+                                               IsRetain,
+                                               IsDup};
+                             (Msg) ->
+                                  lager:warning("dropped message ~p for plugin ~p", [Msg, PluginMod]),
+                                  ok
+                          end, Msgs),
+            vmq_queue:notify(QPid),
+            plugin_receive_loop(PluginPid, PluginMod);
+        {info_req, {Ref, CallerPid}, _} ->
+            CallerPid ! {Ref, {error, i_am_a_plugin}},
+            plugin_receive_loop(PluginPid, PluginMod);
+        disconnect ->
+            ok;
+        {'DOWN', _MRef, process, PluginPid, Reason} ->
+            case (Reason == normal) or (Reason == shutdown) of
+                true ->
+                    ok;
+                false ->
+                    lager:warning("plugin queue loop for ~p stopped due to ~p", [PluginMod, Reason])
+            end;
+        Other ->
+            exit({unknown_msg_in_plugin_loop, Other})
+    end.

--- a/apps/vmq_server/src/vmq_queue.erl
+++ b/apps/vmq_server/src/vmq_queue.erl
@@ -721,7 +721,7 @@ disconnect_sessions(#state{sessions=Sessions}) ->
                       %% calling set_last_waiting_acks/2
                       %% then the 'DOWN' message gets triggerd
                       %% finally deleting the session
-                      SessionPid ! {vmq_mqtt_fsm, disconnect},
+                      vmq_mqtt_fsm_util:send(SessionPid, disconnect),
                       ok
               end, ok, Sessions).
 
@@ -853,15 +853,15 @@ send(#session{pid=Pid, queue=Q} = Session) ->
 
 send(Pid, #queue{type=fifo, queue=Queue, size=Count, drop=Dropped} = Q) ->
     Msgs = queue:to_list(Queue),
-    vmq_mqtt_fsm:send(Pid, {mail, self(), Msgs, Count, Dropped}),
+    vmq_mqtt_fsm_util:send(Pid, {mail, self(), Msgs, Count, Dropped}),
     Q#queue{queue=queue:new(), backup=Queue, size=0, drop=0};
 send(Pid, #queue{type=lifo, queue=Queue, size=Count, drop=Dropped} = Q) ->
     Msgs = lists:reverse(queue:to_list(Queue)),
-    vmq_mqtt_fsm:send(Pid, {mail, self(), Msgs, Count, Dropped}),
+    vmq_mqtt_fsm_util:send(Pid, {mail, self(), Msgs, Count, Dropped}),
     Q#queue{queue=queue:new(), backup=Queue, size=0, drop=0}.
 
 send_notification(#session{pid=Pid} = Session) ->
-    vmq_mqtt_fsm:send(Pid, {mail, self(), new_data}),
+    vmq_mqtt_fsm_util:send(Pid, {mail, self(), new_data}),
     Session#session{status=passive}.
 
 cleanup_session(SubscriberId, #session{queue=#queue{queue=Q, backup=BQ}}) ->

--- a/apps/vmq_server/src/vmq_ranch.erl
+++ b/apps/vmq_server/src/vmq_ranch.erl
@@ -26,6 +26,8 @@
 -export([system_terminate/4]).
 -export([system_code_change/4]).
 
+-define(TO_SESSION, to_session_fsm).
+
 -record(st, {socket,
              buffer= <<>>,
              fsm_mod,
@@ -204,7 +206,7 @@ handle_message({ProtoClosed, _}, #st{proto_tag={_, ProtoClosed, _}, fsm_mod=FsmM
 handle_message({ProtoErr, _, Error}, #st{proto_tag={_, _, ProtoErr}} = State) ->
     _ = vmq_metrics:incr_socket_error(),
     {exit, Error, State};
-handle_message({FsmMod, Msg}, #st{pending=Pending, fsm_state=FsmState0, fsm_mod=FsmMod} = State) ->
+handle_message({?TO_SESSION, Msg}, #st{pending=Pending, fsm_state=FsmState0, fsm_mod=FsmMod} = State) ->
     case FsmMod:msg_in(Msg, FsmState0) of
         {ok, FsmState1, Out} ->
             maybe_flush(State#st{fsm_state=FsmState1,

--- a/apps/vmq_server/src/vmq_systree.erl
+++ b/apps/vmq_server/src/vmq_systree.erl
@@ -128,7 +128,7 @@ handle_info(timeout, true) ->
                       vmq_reg:publish(CAPPublish, RegView, MsgTmpl#vmq_msg{
                                         routing_key=key(Prefix, Metric),
                                         payload=val(Val),
-                                        msg_ref=vmq_mqtt_fsm:msg_ref()
+                                        msg_ref=vmq_mqtt_fsm_util:msg_ref()
                                        })
               end, vmq_metrics:metrics()),
             {noreply, true, Interval};

--- a/apps/vmq_server/src/vmq_websocket.erl
+++ b/apps/vmq_server/src/vmq_websocket.erl
@@ -25,6 +25,7 @@
              bytes_recv={os:timestamp(), 0},
              bytes_sent={os:timestamp(), 0}}).
 
+-define(TO_SESSION, to_session_fsm).
 -define(SUPPORTED_PROTOCOLS, [<<"mqttv3.1">>, <<"mqtt">>]).
 
 
@@ -84,7 +85,7 @@ websocket_info({set_sock_opts, Opts}, Req, State) ->
     [Socket, Transport] = cowboy_req:get([socket, transport], Req),
     Transport:setopts(Socket, Opts),
     {ok, Req, State};
-websocket_info({FsmMod, _}, Req, #st{fsm_mod=FsmMod, fsm_state=terminated} = State) ->
+websocket_info({?TO_SESSION, _}, Req, #st{fsm_state=terminated} = State) ->
     % We got an intermediate message before retrieving {?MODULE, terminate}.
     %
     % The reason for this is that cowboy doesn't provide an equivalent to
@@ -98,7 +99,7 @@ websocket_info({FsmMod, _}, Req, #st{fsm_mod=FsmMod, fsm_state=terminated} = Sta
     % finally shutdown the session we send a {?MODULE, terminate} message
     % to ourself that is handled here.
     {shutdown, Req, State};
-websocket_info({FsmMod, Msg}, Req, #st{fsm_mod=FsmMod, fsm_state=FsmState} = State) ->
+websocket_info({?TO_SESSION, Msg}, Req, #st{fsm_mod=FsmMod, fsm_state=FsmState} = State) ->
     handle_fsm_return(FsmMod:msg_in(Msg, FsmState), Req, State);
 websocket_info(_Info, Req, State) ->
     {ok, Req, State}.

--- a/apps/vmq_server/test/vmq_lvldb_store_SUITE.erl
+++ b/apps/vmq_server/test/vmq_lvldb_store_SUITE.erl
@@ -169,7 +169,7 @@ ref_delete_test(Config) ->
 
 generate_msgs(0, Acc) -> Acc;
 generate_msgs(N, Acc) ->
-    Msg = #vmq_msg{msg_ref=vmq_mqtt_fsm:msg_ref(),
+    Msg = #vmq_msg{msg_ref=vmq_mqtt_fsm_util:msg_ref(),
                    routing_key=vmq_test_utils:rand_bytes(10),
                    payload = vmq_test_utils:rand_bytes(100),
                    mountpoint = "",

--- a/apps/vmq_server/test/vmq_queue_SUITE.erl
+++ b/apps/vmq_server/test/vmq_queue_SUITE.erl
@@ -322,10 +322,10 @@ receive_multi(QPid, Msgs) ->
 
 mock_session(Parent) ->
     receive
-        {vmq_mqtt_fsm, {mail, QPid, new_data}} ->
+        {to_session_fsm, {mail, QPid, new_data}} ->
             vmq_queue:active(QPid),
             mock_session(Parent);
-        {vmq_mqtt_fsm, {mail, QPid, Msgs, _, _}} ->
+        {to_session_fsm, {mail, QPid, Msgs, _, _}} ->
             vmq_queue:notify(QPid),
             timer:sleep(100),
             Parent ! {received, QPid, Msgs},
@@ -337,7 +337,7 @@ mock_session(Parent) ->
     end.
 
 msg(Topic, Payload, QoS) ->
-    #vmq_msg{msg_ref=vmq_mqtt_fsm:msg_ref(),
+    #vmq_msg{msg_ref=vmq_mqtt_fsm_util:msg_ref(),
              mountpoint="",
              routing_key=Topic,
              payload=Payload,


### PR DESCRIPTION
To allow for more than one FSM the send/2 and send_after/2 functions
have been moved to a separate module and now uses a marker which is
independent of the fsm module name (to_session_fsm).