### PR TITLE
Fix session show websocket issue

### DIFF
--- a/apps/vmq_server/src/vmq_mqtt_fsm.erl
+++ b/apps/vmq_server/src/vmq_mqtt_fsm.erl
@@ -1111,7 +1111,7 @@ info(Pid, Items) ->
     Ref = make_ref(),
     CallerRef = {Ref, self()},
     MRef = monitor(process, Pid),
-    Pid ! {info_req, CallerRef, Items},
+    send(Pid, {info_req, CallerRef, Items}),
     receive
         {Ref, Ret} -> Ret;
         {'DOWN', MRef, process, Pid, Reason} ->

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,8 @@
 - Fix some Dialyzer issues.
 - Reduce replication load during a netsplit by making sure data is not attempted
   to be replicated to unreachable nodes.
+- Bugfix: Fix issue causing some `session show` options (`peer_host`,
+  `peer_port`) to not work for websocket clients (#542).
 - Bugfix: Fix routing table initialization issue after restarting a node
   preventing shared subscriptions on a remote node from being included in the
   routing table (#595).


### PR DESCRIPTION
We didn't prefix the `info_req` message with the module which `vmq_websocket` expected and the receive in the fsm would block forever.

Fixes #542 