### PR TITLE
Deliver messages to online shared subscribers first

### DIFF
--- a/apps/vmq_server/src/vmq_shared_subscriptions.erl
+++ b/apps/vmq_server/src/vmq_shared_subscriptions.erl
@@ -57,7 +57,7 @@ publish_online(Msg, Subscribers) ->
                       _ ->
                           Acc
                   end
-          end, Subscribers, [])
+          end, [], Subscribers)
     catch
         done -> ok
     end.

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,9 @@
 
 ## Not yet released (VerneMQ 1.4.0)
 
+- Bugfix: Fix issue preventing messages delivered to a subscriber group from
+  being delivered to the online group members first before attempting delivery
+  to offline queues (#618).
 - Fix some Dialyzer issues.
 - Reduce replication load during a netsplit by making sure data is not attempted
   to be replicated to unreachable nodes.


### PR DESCRIPTION
Fix bug preventing the delivery of messages to a shared subscriber group from being delivered to any online members first before attempting to deliver the messages to offline members.

Fixes #618 