### PR TITLE
Plugin refactoring part 2

### DIFF
--- a/apps/vmq_plugin/src/vmq_plugin.hrl
+++ b/apps/vmq_plugin/src/vmq_plugin.hrl
@@ -1,0 +1,12 @@
+-record(hook, {
+          name        :: atom(),
+          module      :: module(),
+          function    :: atom(),
+          arity       :: non_neg_integer(),
+          compat      :: {Name :: atom(),
+                          Mod   :: module(),
+                          Fun   :: atom(),
+                          Arity :: arity()} |
+                         undefined,
+          opts=[]     :: [any()]
+         }).

--- a/apps/vmq_plugin/src/vmq_plugin_cli.erl
+++ b/apps/vmq_plugin/src/vmq_plugin_cli.erl
@@ -15,6 +15,8 @@
 -module(vmq_plugin_cli).
 -behaviour(clique_handler).
 
+-include("vmq_plugin.hrl").
+
 -export([register_cli/0]).
 
 register_cli() ->
@@ -53,12 +55,12 @@ vmq_plugin_show_cmd() ->
                      ({PN, _,_}=P) when (PluginName == PN) and (HookName == []) ->
                           {true, show_internal_hooks(P, ShowInternal)};
                      ({PN,T,Hooks}) when (PluginName == []) and (HookName =/= []) ->
-                          case [H|| {HN,_,_,_, _}=H<-Hooks, HN ==  HookName] of
+                          case [H|| {HN,_,_,_,_,_}=H<-Hooks, HN ==  HookName] of
                               [] -> false;
                               Hs -> show_internal_hooks({PN, T, Hs}, ShowInternal)
                           end;
                      ({PN,T,Hooks}) when (PluginName == PN) and (HookName =/= []) ->
-                          case [H|| {HN,_,_,_, _}=H<-Hooks, HN == HookName] of
+                          case [H|| {HN,_,_,_,_,_}=H<-Hooks, HN == HookName] of
                               [] -> false;
                               Hs -> show_internal_hooks({PN, T, Hs}, ShowInternal)
                           end;
@@ -74,7 +76,7 @@ vmq_plugin_show_cmd() ->
     clique:register_command(Cmd, KeySpecs, FlagSpecs, Callback).
 
 show_internal_hooks({PN,T,Hs}, ShowInternal) ->
-    {PN, T, [ Hook || {_,_,_,_,Opts}=Hook <-Hs,
+    {PN, T, [ Hook || {_,_,_,_,_,Opts}=Hook <-Hs,
                       show_internal_hook(T, Opts, ShowInternal)]}.
 
 show_internal_hook(_, Opts, ShowInternal) ->
@@ -88,10 +90,10 @@ new_row(Plugin, Type, Hooks, Acc) ->
       {'Hook(s)', fmt_hooks(Hooks)}, {'M:F/A', fmt_mfas(Hooks)}] | Acc].
 
 fmt_hooks(Hooks) ->
-    lists:flatten([io_lib:format("~p~n", [H]) || {H,_,_,_,_} <- Hooks]).
+    lists:flatten([io_lib:format("~p~n", [H]) || {H,_,_,_,_,_} <- Hooks]).
 
 fmt_mfas(Hooks) ->
-    lists:flatten([io_lib:format("~p:~p/~p~n", [M,F,A]) || {_,M,F,A,_} <- Hooks]).
+    lists:flatten([io_lib:format("~p:~p/~p~n", [M,F,A]) || {_,M,F,A,_,_} <- Hooks]).
 
 extract_table(Plugins) ->
     lists:foldl(
@@ -102,13 +104,18 @@ extract_table(Plugins) ->
       end, [], Plugins).
 
 get_module_hooks(Mod, Hooks) ->
-    lists:map(fun({F, A}) -> {F, Mod, F, A};
-                 ({H, F, A}) -> {H, Mod, F, A, []}
+    lists:map(fun(#hook{name = N, module = M,
+                        function = F, arity =A,
+                        compat = C, opts = Opts}) when M =:= Mod ->
+                      {N, M, F, A, C, Opts}
               end, Hooks).
 
 get_app_hooks(Hooks) ->
-    lists:map(fun({_,_,_,_,_} = H) -> H;
-                 ({M,F,A,Opts}) -> {F,M,F,A,Opts}
+    lists:map(fun(
+                #hook{name = N, module = M,
+                      function = F, arity =A,
+                      compat = C, opts = Opts}) ->
+                      {N, M, F, A, C, Opts}
               end, Hooks).
 
 vmq_plugin_flag_specs() ->

--- a/apps/vmq_plugin/src/vmq_plugin_helper.erl
+++ b/apps/vmq_plugin/src/vmq_plugin_helper.erl
@@ -18,6 +18,10 @@
 
 all(Hooks, Params) ->
     all(Hooks, Params, []).
+
+all([{compat, Hook, CompatMod, CompatFun, Module, Fun}|Rest], Params, Acc) ->
+    Res = apply(CompatMod, CompatFun, [Hook, Module, Fun, Params]),
+    all(Rest, Params, [Res|Acc]);
 all([{Module, Fun}|Rest], Params, Acc) ->
     Res = apply(Module, Fun, Params),
     all(Rest, Params, [Res|Acc]);
@@ -25,6 +29,14 @@ all([], _, Acc) -> lists:reverse(Acc).
 
 all_till_ok([{Module, Fun}|Rest], Params) ->
     case apply(Module, Fun, Params) of
+        ok -> ok;
+        {ok, V} -> {ok, V};
+        {error, Error} -> {error, Error};
+        next -> all_till_ok(Rest, Params);
+        E -> {error, E}
+    end;
+all_till_ok([{compat, Hook, CompatMod, CompatFun, Module, Fun}|Rest], Params) ->
+    case apply(CompatMod, CompatFun, [Hook, Module, Fun, Params]) of
         ok -> ok;
         {ok, V} -> {ok, V};
         {error, Error} -> {error, Error};

--- a/apps/vmq_plugin/src/vmq_plugin_mgr.erl
+++ b/apps/vmq_plugin/src/vmq_plugin_mgr.erl
@@ -66,6 +66,20 @@
                    atom(),
                    non_neg_integer()}.
 
+-record(hook, {
+          name        :: atom(),
+          module      :: module(),
+          function    :: atom(),
+          arity       :: non_neg_integer(),
+          compatmod   :: module() | undefined,
+          compatfun   :: atom() | undefined,
+          opts        :: [any()]
+         }).
+
+-type raw_hook() :: {atom(), module(), atom(), non_neg_integer()}.
+
+-type hook() :: #hook{}.
+
 %%%===================================================================
 %%% API
 %%%===================================================================
@@ -307,10 +321,11 @@ get_new_hooks({application, Name, Opts}, OldPlugins) ->
         false -> {application, Name, Opts}
     end.
 
-plugins_have_hook(Hook, OldPlugins) ->
+plugins_have_hook({Name, Module, Fun, Arity}, OldPlugins) ->
     lists:any(
-      fun({H,M,F,A,_}) ->
-              {H,M,F,A} =:= Hook
+      fun(#hook{name = H, module = M,
+                function = F, arity = A}) ->
+              {H,M,F,A} =:= {Name, Module, Fun, Arity}
       end,
       extract_hooks(OldPlugins)).
 
@@ -650,6 +665,7 @@ check_app_hooks(App, [{_HookName, Module, Fun, Arity, Opts}|Rest])
     end;
 check_app_hooks(_, []) -> hooks_ok.
 
+-spec extract_hooks([any()]) -> [hook()].
 extract_hooks(CheckedPlugins) ->
     extract_hooks(CheckedPlugins, []).
 
@@ -669,25 +685,28 @@ extract_hooks([{application, _Name, Options}|Rest], Acc) ->
 
 extract_app_hooks([], Acc) -> Acc;
 extract_app_hooks([{Mod, Fun, Arity}|Rest], Acc) ->
-    extract_app_hooks(Rest, [{Fun, Mod, Fun, Arity, []}|Acc]);
+    extract_app_hooks(Rest, [#hook{name = Fun, module = Mod, function = Fun, arity = Arity, opts = []}|Acc]);
 extract_app_hooks([{Mod, Fun, Arity, Opts}|Rest], Acc) when is_list(Opts) ->
-    extract_app_hooks(Rest, [{Fun, Mod, Fun, Arity, Opts}|Acc]);
-extract_app_hooks([{H,M,F,A}|Rest], Acc) ->
-    extract_app_hooks([{H,M,F,A,[]}|Rest], Acc);
-extract_app_hooks([{H,M,F,A, Opts}|Rest], Acc) ->
-    extract_app_hooks(Rest, [{H,M,F,A, Opts}|Acc]).
+    extract_app_hooks(Rest, [#hook{name = Fun, module = Mod, function = Fun, arity = Arity, opts = Opts}|Acc]);
+extract_app_hooks([{Name, Mod, Fun, Arity}|Rest], Acc) ->
+    extract_app_hooks(Rest, [#hook{name = Name, module = Mod, function = Fun, arity = Arity, opts = []}|Acc]);
+extract_app_hooks([{Name, Mod, Fun, Arity, Opts}|Rest], Acc) ->
+    extract_app_hooks(Rest, [#hook{name = Name, module = Mod, function = Fun, arity = Arity, opts = Opts}|Acc]).
 
 extract_module_hooks(_, [], Acc) ->
     Acc;
-extract_module_hooks(ModName, [{HookName, Fun, Arity}|Rest], Acc) ->
-    extract_module_hooks(ModName, Rest, [{HookName, ModName, Fun, Arity, []}|Acc]);
+extract_module_hooks(ModName, [{Name, Fun, Arity}|Rest], Acc) ->
+    extract_module_hooks(ModName, Rest,
+                         [#hook{name = Name, module = ModName, function = Fun, arity = Arity, opts = []}|Acc]);
 extract_module_hooks(ModName, [{Fun, Arity}|Rest], Acc) ->
-    extract_module_hooks(ModName, Rest, [{Fun, ModName, Fun, Arity, []}|Acc]).
+    extract_module_hooks(ModName, Rest,
+                         [#hook{name = Fun, module = ModName, function = Fun, arity = Arity, opts = []}|Acc]).
 
 compile_hooks(CheckedPlugins) ->
     RawPlugins = extract_hooks(CheckedPlugins),
-    Hooks = [{H,M,F,A} || {H,M,F,A,_} <-
-                              lists:keysort(1, lists:flatten(RawPlugins))],
+    Hooks = lists:sort(fun(#hook{name = LName}, #hook{name = RName}) ->
+                               LName =< RName
+                       end, lists:flatten(RawPlugins)),
     M1 = smerl:new(vmq_plugin),
     {OnlyClauses, OnlyInfo} = only_clauses(1, Hooks, {nil, nil}, [], []),
     {ok, M2} = smerl:add_func(M1, {function, 1, only, 2, OnlyClauses}),
@@ -711,20 +730,21 @@ info_only_clause(Hooks) ->
     {clause, 1,
      [{atom, 1, only}],
      [],
-     [list_const(true, Hooks)]
+     [list_const(true, embed_hooks(Hooks))]
     }.
 info_all_clause(Hooks) ->
     {clause, 2,
      [{atom, 1, all}],
      [],
-     [list_const(true, Hooks)]
+     [list_const(true, embed_hooks(Hooks))]
     }.
 
-only_clauses(I, [{Name, _, _, Arity} | Rest], {Name, Arity} = Last, Acc, Info) ->
+only_clauses(I, [#hook{name = Name, arity = Arity} | Rest], {Name, Arity} = Last, Acc, Info) ->
     %% we already serve this only-clause
     %% see head of Acc
     only_clauses(I, Rest, Last, Acc, Info);
-only_clauses(I, [{Name, Module, Fun, Arity} = Hook | Rest], _, Acc, Info) ->
+only_clauses(I, [#hook{name = Name, module = Module,
+                       function = Fun, arity = Arity} = Hook | Rest], _, Acc, Info) ->
     Clause =
     clause(I, Name, Arity,
            [{call, 1, {atom, 1, apply},
@@ -743,8 +763,8 @@ not_found_clause(I) ->
      [{tuple, 1, [{atom, 1, error}, {atom, 1, no_matching_hook_found}]}]
     }.
 
-all_clauses(I, [{Name, _, _, Arity} = Hook |Rest], Acc, Info) ->
-    Hooks = [H || {N, _, _, A} = H <- Rest,
+all_clauses(I, [#hook{name = Name, arity = Arity} = Hook |Rest], Acc, Info) ->
+    Hooks = [H || #hook{name = N, arity = A} = H <- Rest,
                   (N == Name) and (A == Arity)],
     Clause =
     clause(I, Name, Arity,
@@ -752,7 +772,7 @@ all_clauses(I, [{Name, _, _, Arity} = Hook |Rest], Acc, Info) ->
              [{atom, 1, vmq_plugin_helper},
               {atom, 1, all},
               {cons, 1,
-               list_const(false, [Hook|Hooks]),
+               list_const(false, embed_hooks([Hook|Hooks])),
                {cons, 1,
                 {var, 1, 'Params'},
                 {nil, 1}}}]
@@ -761,9 +781,8 @@ all_clauses(I, [{Name, _, _, Arity} = Hook |Rest], Acc, Info) ->
 all_clauses(I, [], Acc, Info) ->
     {lists:reverse([not_found_clause(I) | Acc]), Info}.
 
-
-all_till_ok_clauses(I, [{Name, _, _, Arity} = Hook |Rest], Acc) ->
-    Hooks = [H || {N, _, _, A} = H <- Rest,
+all_till_ok_clauses(I, [#hook{name = Name, arity = Arity} = Hook |Rest], Acc) ->
+    Hooks = [H || #hook{name = N, arity = A} = H <- Rest,
                   (N == Name) and (A == Arity)],
     Clause =
     clause(I, Name, Arity,
@@ -771,7 +790,7 @@ all_till_ok_clauses(I, [{Name, _, _, Arity} = Hook |Rest], Acc) ->
              [{atom, 1, vmq_plugin_helper},
               {atom, 1, all_till_ok},
               {cons, 1,
-               list_const(false, [Hook|Hooks]),
+               list_const(false, embed_hooks([Hook|Hooks])),
                {cons, 1,
                 {var, 1, 'Params'},
                 {nil, 1}}}]
@@ -820,6 +839,14 @@ list_const(true, [{Name, Module, Fun, Arity}|Rest]) ->
        {atom, 1, Fun},
        {integer, 1, Arity}]
      }, list_const(true, Rest)}.
+
+-spec embed_hooks([hook()]) -> [raw_hook()].
+embed_hooks(Hooks) ->
+    lists:map(
+      fun(#hook{name = N, module = M,
+                function = F, arity = A}) ->
+              {N, M, F, A}
+      end, Hooks).
 
 -ifdef(TEST).
 %%%===================================================================

--- a/apps/vmq_plugin/src/vmq_plugin_mgr.erl
+++ b/apps/vmq_plugin/src/vmq_plugin_mgr.erl
@@ -15,6 +15,8 @@
 -module(vmq_plugin_mgr).
 -behaviour(gen_server).
 
+-include("vmq_plugin.hrl").
+
 %% API
 -export([start_link/0,
          stop/0,
@@ -67,19 +69,6 @@
                    atom(),
                    atom(),
                    non_neg_integer()}.
-
--record(hook, {
-          name        :: atom(),
-          module      :: module(),
-          function    :: atom(),
-          arity       :: non_neg_integer(),
-          compat      :: {Name :: atom(),
-                          Mod   :: module(),
-                          Fun   :: atom(),
-                          Arity :: arity()} |
-                         undefined,
-          opts=[]     :: [any()]
-         }).
 
 -type raw_hook() :: {atom(), module(), atom(), non_neg_integer()} |
                     {compat,

--- a/apps/vmq_plugin/src/vmq_plugin_mgr.erl
+++ b/apps/vmq_plugin/src/vmq_plugin_mgr.erl
@@ -76,11 +76,21 @@
           compat      :: {Name :: atom(),
                           Mod   :: module(),
                           Fun   :: atom(),
-                          Arity :: arity()},
+                          Arity :: arity()} |
+                         undefined,
           opts=[]     :: [any()]
          }).
 
--type raw_hook() :: {atom(), module(), atom(), non_neg_integer()}.
+-type raw_hook() :: {atom(), module(), atom(), non_neg_integer()} |
+                    {compat,
+                     N :: atom(),
+                     M :: module(),
+                     F :: atom(),
+                     A :: non_neg_integer(),
+                     CH :: atom(),
+                     CM :: module(),
+                     CF :: atom(),
+                     CA :: non_neg_integer()}.
 
 -type hook() :: #hook{}.
 
@@ -128,7 +138,7 @@ enable_module_plugin(HookName, Module, Fun, Arity, Opts) when
     Hook = case lists:keyfind(compat, 1, Opts) of
                {compat, {CH, CM, CF, CA}} ->
                    #hook{name = HookName, module = Module, function = Fun, arity = Arity,
-                        compat = {CH, CM, CF, CA}};
+                         compat = {CH, CM, CF, CA}};
                false ->
                    #hook{name = HookName, module = Module, function = Fun, arity = Arity}
            end,

--- a/apps/vmq_plugin/test/test_compat_mod.erl
+++ b/apps/vmq_plugin/test/test_compat_mod.erl
@@ -1,0 +1,14 @@
+-module(test_compat_mod).
+
+-compile(export_all).
+-compile(nowarn_export_all).
+
+sample_hook_v1_to_v0(sample_hook_name_v0, Mod, Fun, [A1, A2, A3]) ->
+    %% transform arguments and return values as needed. For now we
+    %% just keep it simple and remove one argument and add it back to
+    %% the return value of the v0 hook.
+    {ok, {A1, A2}} = apply(Mod, Fun, [A1, A2]),
+    {ok, {A1, A2, A3}}.
+
+sample_hook_v0(A1, A2) ->
+    {ok, {A1,A2}}.

--- a/apps/vmq_plugin/test/vmq_plugin_SUITE.erl
+++ b/apps/vmq_plugin/test/vmq_plugin_SUITE.erl
@@ -132,8 +132,7 @@ module_plugin_with_compat_hooks(_Config) ->
                                              test_compat_mod,
                                              sample_hook_v0,
                                              2,
-                                             [
-                                              {compat, {sample_hook_name_v1,
+                                             [{compat, {sample_hook_name_v1,
                                                         test_compat_mod,
                                                         sample_hook_v1_to_v0,
                                                         3}}
@@ -147,7 +146,34 @@ module_plugin_with_compat_hooks(_Config) ->
     %% check that the compat hook works as well.
     {ok, {1,2,3}} = vmq_plugin:all_till_ok(sample_hook_name_v1, [1,2,3]),
     [{ok, {1,2,3}}] = vmq_plugin:all(sample_hook_name_v1, [1,2,3]),
-    {ok, {1,2,3}} = vmq_plugin:only(sample_hook_name_v1, [1,2,3]).
+    {ok, {1,2,3}} = vmq_plugin:only(sample_hook_name_v1, [1,2,3]),
+
+    ok = vmq_plugin_mgr:disable_module_plugin(sample_hook_name_v0,
+                                              test_compat_mod,
+                                              sample_hook_v0,
+                                              2,
+                                              [{compat, {sample_hook_name_v1,
+                                                         test_compat_mod,
+                                                         sample_hook_v1_to_v0,
+                                                         3}}
+                                              ]),
+
+    ok = vmq_plugin_mgr:disable_module_plugin(sample_hook_name_v0,
+                                              test_compat_mod,
+                                              sample_hook_v0,
+                                              2,
+                                              []),
+
+    %% check the normal hook is gone
+    {error, no_matching_hook_found} = vmq_plugin:all_till_ok(sample_hook_name_v0, [1,2]),
+    {error, no_matching_hook_found} = vmq_plugin:all(sample_hook_name_v0, [1,2]),
+    {error, no_matching_hook_found} = vmq_plugin:only(sample_hook_name_v0, [1,2]),
+
+    %% check that the compat hook is gone as well.
+    {error, no_matching_hook_found} = vmq_plugin:all_till_ok(sample_hook_name_v1, [1,2,3]),
+    {error, no_matching_hook_found} = vmq_plugin:all(sample_hook_name_v1, [1,2,3]),
+    {error, no_matching_hook_found} = vmq_plugin:only(sample_hook_name_v1, [1,2,3]).
+
 
 
 sample_hook_function() ->


### PR DESCRIPTION
This builds on top of #633 which should be reviewed and merged first (this PR then has fewer changes)

This PR makes it possible to specify compatibility data for an application plugin. This compatibility data (basically a module and a function) can be used to wrap existing plugin hooks, so they can be converted to the format of a new hook by wrangling parameters and return values.

The PR also refactors the internal representation of plugin hooks to use records instead of matching on different tuple sizes.

We will need this to be able to reuse old plugins in an MQTTv5 context.

Note: before this PR can be merged I have to do some experiments actually using this to make sure the API works... But a basic review would be nice.