### PR TITLE
Handle `normal` exit when fetching from `vmq_ql_query`

### DIFF
--- a/apps/vmq_ql/src/vmq_ql_query.erl
+++ b/apps/vmq_ql/src/vmq_ql_query.erl
@@ -51,11 +51,15 @@ start_link(Mgr, QueryString) ->
     gen_server:start_link(?MODULE, [Mgr, QueryString], []).
 
 fetch(Pid, Ordering, Limit) ->
-    try
-        gen_server:call(Pid, {fetch, Ordering, Limit}, infinity)
-    catch
-        exit:{noproc, _} ->
-            []
+    case catch gen_server:call(Pid, {fetch, Ordering, Limit}, infinity) of
+        {'EXIT', {normal, _}} ->
+            [];
+        {'EXIT', {noproc, _}} ->
+            [];
+        {'EXIT', Reason} ->
+            exit(Reason);
+        Ret ->
+            Ret
     end.
 
 %%%===================================================================

--- a/changelog.md
+++ b/changelog.md
@@ -28,6 +28,7 @@
 - Bugfix: Fix routing table initialization issue after restarting a node
   preventing shared subscriptions on a remote node from being included in the
   routing table (#595).
+- Bugfix: Fix race condition when fetching data from the internal query subsystem.
 
 ## VerneMQ 1.3.0
 


### PR DESCRIPTION
might be related to what has been reported here https://github.com/erlio/vernemq/issues/619