### PR TITLE
Make it possible to specify the allowed MQTT protocol levels

### DIFF
--- a/apps/vmq_server/priv/vmq_server.schema
+++ b/apps/vmq_server/priv/vmq_server.schema
@@ -627,6 +627,76 @@
                                                                                   ]}.
 
 
+
+%% @doc 'listener.tcp.allowed_protocol_versions' configures which
+%% protocol versions are allowed for an MQTT listener. The allowed
+%% protocol versions can be specified the tcp, websocket or ssl level:
+%%
+%%     - listener.tcp.allowed_protocol_versions
+%%     - listener.ws.allowed_protocol_versions
+%%     - listener.wss.allowed_protocol_versions
+%%     - listener.ssl.allowed_protocol_versions
+%%
+%% or for a specific listener:
+%%
+%%     - listener.tcp.my_tcp_listener.allowed_protocol_versions
+%%     - listener.ws.my_ws_listener.allowed_protocol_versions
+%%     - listener.wss.my_ws_listener.allowed_protocol_versions
+%%     - listener.ssl.my_ws_listener.allowed_protocol_versions
+%%
+%%
+{mapping, "listener.tcp.allowed_protocol_versions", "vmq_server.listeners",
+ [
+  {default, "[3,4]"},
+  {datatype, string},
+  hidden
+ ]}.
+
+{mapping, "listener.tcp.$name.allowed_protocol_versions", "vmq_server.listeners",
+ [
+  {datatype, string},
+  hidden
+ ]}.
+
+{mapping, "listener.ws.allowed_protocol_versions", "vmq_server.listeners",
+ [
+  {default, "[3,4]"},
+  {datatype, string},
+  hidden
+ ]}.
+
+{mapping, "listener.ws.$name.allowed_protocol_versions", "vmq_server.listeners",
+ [
+  {datatype, string},
+  hidden
+ ]}.
+
+{mapping, "listener.wss.allowed_protocol_versions", "vmq_server.listeners",
+ [
+  {default, "[3,4]"},
+  {datatype, string},
+  hidden
+ ]}.
+
+{mapping, "listener.wss.$name.allowed_protocol_versions", "vmq_server.listeners",
+ [
+  {datatype, string},
+  hidden
+ ]}.
+
+{mapping, "listener.ssl.allowed_protocol_versions", "vmq_server.listeners",
+ [
+  {default, "[3,4]"},
+  {datatype, string},
+  hidden
+ ]}.
+
+{mapping, "listener.ssl.$name.allowed_protocol_versions", "vmq_server.listeners",
+ [
+  {datatype, string},
+  hidden
+ ]}.
+
 %% @doc listener.vmq.clustering is the IP address and TCP port that
 %% the broker will bind to accept connections from other cluster
 %% nodes e.g:

--- a/apps/vmq_server/src/vmq_ranch_config.erl
+++ b/apps/vmq_server/src/vmq_ranch_config.erl
@@ -257,5 +257,7 @@ default_session_opts(Opts) ->
             false -> MaybeSSLDefaults;
             {_, V1} -> [{proxy_protocol_use_cn_as_username, V1}|MaybeSSLDefaults]
         end,
+    AllowedProtocolVersions = proplists:get_value(allowed_protocol_versions, Opts, [3,4]),
     %% currently only the mountpoint option is supported
-    [{mountpoint, proplists:get_value(mountpoint, Opts, "")}|MaybeProxyDefaults].
+    [{mountpoint, proplists:get_value(mountpoint, Opts, "")},
+     {allowed_protocol_versions, AllowedProtocolVersions}|MaybeProxyDefaults].

--- a/apps/vmq_server/test/vmq_schema_SUITE.erl
+++ b/apps/vmq_server/test/vmq_schema_SUITE.erl
@@ -38,7 +38,9 @@ all() ->
     [proxy_protocol_inheritance_test,
      proxy_protocol_override_test,
      ssl_certs_opts_inheritance_test,
-     ssl_certs_opts_override_test].
+     ssl_certs_opts_override_test,
+     allowed_protocol_versions_inheritance_test,
+     allowed_protocol_versions_override_test].
 
 
 ssl_certs_opts_inheritance_test(_Config) ->
@@ -184,17 +186,73 @@ proxy_protocol_override_test(_Config) ->
     true = expect(Conf, [vmq_server, listeners, http,  {{127,0,0,1}, 8888},proxy_protocol]),
     true = expect(Conf, [vmq_server, listeners, mqttws,{{127,0,0,1}, 800}, proxy_protocol]).
 
+allowed_protocol_versions_inheritance_test(_Config) ->
+    Conf = [%% required settings the listener translator.
+            {["listener","max_connections"], "10000"},
+            {["listener","nr_of_acceptors"], "100"},
+            %% tcp/mqtt
+            {["listener","tcp","allowed_protocol_versions"], "[3,4,5]"},
+            {["listener","tcp","default"],"127.0.0.1:1884"},
+            %% tcp/ssl/mqtt
+            {["listener","ssl","allowed_protocol_versions"], "[3,4,5]"},
+            {["listener","ssl","default"],"127.0.0.1:8884"},
+            %% websocket
+            {["listener","ws","allowed_protocol_versions"], "[3,4,5]"},
+            {["listener","ws","default"],"127.0.0.1:800"},
+            %% websocket/ssl
+            {["listener","wss","allowed_protocol_versions"], "[3,4,5]"},
+            {["listener","wss","default"],"127.0.0.1:900"}],
+    [3,4,5] = expect(Conf, [vmq_server, listeners, mqtt,  {{127,0,0,1}, 1884},allowed_protocol_versions]),
+    [3,4,5] = expect(Conf, [vmq_server, listeners, mqtts,  {{127,0,0,1}, 8884},allowed_protocol_versions]),
+    [3,4,5] = expect(Conf, [vmq_server, listeners, mqttws,{{127,0,0,1}, 800}, allowed_protocol_versions]),
+    [3,4,5] = expect(Conf, [vmq_server, listeners, mqttwss,{{127,0,0,1}, 900}, allowed_protocol_versions]).
+
+allowed_protocol_versions_override_test(_Config) ->
+    Conf = [%% required settings on listener translator.
+            {["listener","max_connections"], "10000"},
+            {["listener","nr_of_acceptors"], "100"},
+            %% tcp/mqtt
+            {["listener","tcp","allowed_protocol_versions"], "[3,4]"},
+            {["listener","tcp","default"],"127.0.0.1:1884"},
+            {["listener","tcp","default","allowed_protocol_versions"], "[4]"},
+            %% tcp/ssl/mqtt
+            {["listener","ssl","allowed_protocol_versions"], "[3,4]"},
+            {["listener","ssl","default"],"127.0.0.1:8884"},
+            {["listener","ssl","default","allowed_protocol_versions"], "[4]"},
+            %% websocket
+            {["listener","ws","allowed_protocol_versions"], "[3,4]"},
+            {["listener","ws","default"],"127.0.0.1:800"},
+            {["listener","ws","default","allowed_protocol_versions"], "[4]"},
+            %% websocket/ssl
+            {["listener","wss","allowed_protocol_versions"], "[3,4]"},
+            {["listener","wss","default"],"127.0.0.1:900"},
+            {["listener","wss","default","allowed_protocol_versions"], "[4]"}
+           ],
+    [4] = expect(Conf, [vmq_server, listeners, mqtt, {{127,0,0,1}, 1884}, allowed_protocol_versions]),
+    [4] = expect(Conf, [vmq_server, listeners, mqttws, {{127,0,0,1}, 800}, allowed_protocol_versions]),
+    [4] = expect(Conf, [vmq_server, listeners, mqttws,{{127,0,0,1}, 800}, allowed_protocol_versions]),
+    [4] = expect(Conf, [vmq_server, listeners, mqttwss,{{127,0,0,1}, 900}, allowed_protocol_versions]).
+
+
+-define(stacktrace, try throw(foo) catch foo -> erlang:get_stacktrace() end).
+
 expect(Conf, Setting) ->
     Schema = cuttlefish_schema:files([code:priv_dir(vmq_server) ++ "/vmq_server.schema"]),
-    Gen = cuttlefish_generator:map(Schema,Conf),
-    deep_find(Gen, Setting).
+    case cuttlefish_generator:map(Schema,Conf) of
+        {error, _, _} = E ->
+            StackTrace = ?stacktrace,
+            throw({E, StackTrace});
+        Gen ->
+            deep_find(Gen, Setting)
+    end.
 
 deep_find(Value, []) ->
     Value;
 deep_find(Conf, [Prop|T]) ->
     case lists:keyfind(Prop, 1, Conf) of
         false ->
-            throw({could_not_find, Prop, in, Conf});
+            StackTrace = ?stacktrace,
+            throw({could_not_find, Prop, in, Conf, StackTrace});
         {Prop, Value} ->
             deep_find(Value, T)
     end.

--- a/changelog.md
+++ b/changelog.md
@@ -38,6 +38,13 @@
   routing table (#595).
 - Bugfix: Fix race condition when fetching data from the internal query subsystem.
 - Fix build issue on Raspberry PI (`make rpi-32`).
+- Make it possible to specify which protocol versions are allowed on an MQTT
+  listener. By default the protocol versions allowed are versions 3 and 4 (MQTT
+  v3.1 and v3.1.1 respectively). To set the allowed protocol versions one can
+  use `listener.tcp.allowed_protocol_versions = [3,4]` on the transport level or
+  for a specific listener using
+  `listener.tcp.specific_listener.allowed_protocol_versions`.
+
 
 ## VerneMQ 1.3.0
 


### PR DESCRIPTION
This PR makes it possible to specify on the transport level and specific listeners which MQTT protocol levels are allowed. The default is to allow MQTT v3.1 (proto version 3) and v3.1.1 (proto version 4).

The motivation for this PR is to be able to introduce MQTTv5 but not have MQTTv5 enabled by default on existing listeners as that would be unexpected behaviour for most users.

Note, this introduces a new field in the state of the MQTT FSM (`allowed_protocol_version`). A way to avoid this would be to only be able to specify the allowed protocol versions globally (not on the listener or transport levels). The user would still be able to override the protocol level via `auth_on_register`.

The question is, do we need the fine-grained control on the listener level or is a global configuration enough?