### PR TITLE
Rename hook return value to make it generic

### DIFF
--- a/apps/vmq_plugin/src/vmq_plugin_helper.erl
+++ b/apps/vmq_plugin/src/vmq_plugin_helper.erl
@@ -31,7 +31,7 @@ all_till_ok([{Module, Fun}|Rest], Params) ->
     case apply(Module, Fun, Params) of
         ok -> ok;
         {ok, V} -> {ok, V};
-        {continue_auth, V} -> {continue_auth, V};
+        {incomplete, V} -> {incomplete, V};
         {error, Error} -> {error, Error};
         next -> all_till_ok(Rest, Params);
         E -> {error, E}

--- a/apps/vmq_server/src/vmq_mqtt5_fsm.erl
+++ b/apps/vmq_server/src/vmq_mqtt5_fsm.erl
@@ -245,7 +245,7 @@ pre_connect_auth(#mqtt5_auth{properties = #{p_authentication_method := AuthMetho
             OutProps = proplists:get_value(properties, Modifiers, #{}),
             check_connect(ConnectFrame, OutProps,
                           State#state{enhanced_auth = NewAuthData});
-        {continue_auth, Modifiers} ->
+        {incomplete, Modifiers} ->
             %% TODOv5: filter / rename properties?
             OutProps = proplists:get_value(properties, Modifiers, #{}),
             Frame = #mqtt5_auth{reason_code = ?M5_CONTINUE_AUTHENTICATION,
@@ -476,7 +476,7 @@ connected(#mqtt5_auth{properties=#{p_authentication_method := AuthMethod} = Prop
                   username = proplists:get_value(username, Modifiers, State#state.username)
                  },
             {NewState, [Frame]};
-        {continue_auth, Modifiers} ->
+        {incomplete, Modifiers} ->
             OutProps = proplists:get_value(properties, Modifiers, #{}),
             %% TODOv5: filter / rename properties?
             Frame = #mqtt5_auth{reason_code = ?M5_CONTINUE_AUTHENTICATION,
@@ -592,7 +592,7 @@ check_enhanced_auth(#mqtt5_connect{properties=#{p_authentication_method := AuthM
             OutProps = proplists:get_value(properties, Modifiers, #{}),
             EnhancedAuth = #auth_data{method = AuthMethod},
             check_connect(F, OutProps, State#state{enhanced_auth = EnhancedAuth});
-        {continue_auth, Modifiers} ->
+        {incomplete, Modifiers} ->
             EnhancedAuth = #auth_data{method = AuthMethod,
                                       data = F},
             OutProps = proplists:get_value(properties, Modifiers, #{}),

--- a/apps/vmq_server/test/vmq_mqtt5_SUITE.erl
+++ b/apps/vmq_server/test/vmq_mqtt5_SUITE.erl
@@ -338,11 +338,11 @@ on_auth_bad_method_hook(#{p_authentication_method := _, p_authentication_data :=
     {error, bad_auth_method}.
 
 on_auth_hook(#{p_authentication_method := ?AUTH_METHOD, p_authentication_data := <<"Client1">>}) ->
-    {continue_auth, [{properties,
-                      #{p_authentication_method => ?AUTH_METHOD, p_authentication_data => <<"Server1">>}}]};
+    {incomplete, [{properties,
+                   #{p_authentication_method => ?AUTH_METHOD, p_authentication_data => <<"Server1">>}}]};
 on_auth_hook(#{p_authentication_method := ?AUTH_METHOD, p_authentication_data := <<"Client2">>}) ->
-    {continue_auth, [{properties,
-                      #{p_authentication_method => ?AUTH_METHOD, p_authentication_data => <<"Server2">>}}]};
+    {incomplete, [{properties,
+                   #{p_authentication_method => ?AUTH_METHOD, p_authentication_data => <<"Server2">>}}]};
 on_auth_hook(#{p_authentication_method := ?AUTH_METHOD, p_authentication_data := <<"Client3">>}) ->
     %% return ok which will trigger the connack being sent to the
     %% client *or* an AUTH ok


### PR DESCRIPTION
The plugin system should be as general as possible and not know about
any of the details of MQTT.