### PR TITLE
Replace groupify with cth

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,6 @@ Currently supported features are:
 
 Currently known issues for MQTTv5 are:
 
-- QoS 1/2 retries are only allowed after a network connection reconnect,
-  currently retries are made exactly as in MQTTv4.
 - Tracing (`vmq-admin trace`) doesn't yet support tracing MQTTv5 sessions.
 - New subscription flags (No Local, Retain as Published, Retain Handling) are
   ignored and subscriptions therefore currently work as in MQTTv4.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # VerneMQ MQTTv5 preview
 
+[![Build Status](https://travis-ci.org/erlio/vernemq.svg?branch=mqtt5-preview)](https://travis-ci.org/erlio/vernemq)
+[![Slack Invite](https://slack-invite.vernemq.com/badge.svg)](https://slack-invite.vernemq.com)
+
+
 This branch is an early release of VerneMQ with MQTTv5 support and is made
 public to allow the community and industry to start working with MQTTv5 and to
 get as much feedback as possible.

--- a/apps/vmq_server/test/mqtt5_v4compat.erl
+++ b/apps/vmq_server/test/mqtt5_v4compat.erl
@@ -18,7 +18,6 @@
          gen_disconnect/1]).
 
 -export([protover/1]).
--export([groupify/2]).
 
 -include_lib("vmq_commons/include/vmq_types_mqtt5.hrl").
 
@@ -193,9 +192,3 @@ ensure_binary(empty) -> empty. % for test purposes
 
 protover(Config) ->
     proplists:get_value(protover, Config).
-
-groupify(String, Config) when is_list(String) ->
-    case protover(Config) of
-        4 -> String ++ "-mqttv4";
-        5 -> String ++ "-mqttv5"
-    end.

--- a/apps/vmq_server/test/vmq_publish_SUITE.erl
+++ b/apps/vmq_server/test/vmq_publish_SUITE.erl
@@ -13,7 +13,7 @@ init_per_suite(Config) ->
     cover:start(),
     vmq_test_utils:setup(),
     vmq_server_cmd:listener_start(1888, [{allowed_protocol_versions, "3,4,5"}]),
-    [S|Config].
+    [S, {ct_hooks, vmq_cth} |Config].
 
 end_per_suite(_Config) ->
     vmq_server_cmd:listener_stop(1888, "127.0.0.1", false),
@@ -119,7 +119,7 @@ publish_qos2_test(Config) ->
 
 
 publish_b2c_disconnect_qos1_test(Config) ->
-    ClientId = mqtt5_v4compat:groupify("pub-qos1-disco-test", Config),
+    ClientId = vmq_cth:ustr(Config) ++ "pub-qos1-disco-test",
     Connect = mqtt5_v4compat:gen_connect(ClientId,
                                          [{keepalive, 60}, {clean_session, false}], Config),
     Connack1 = mqtt5_v4compat:gen_connack(success, Config),
@@ -157,7 +157,7 @@ publish_b2c_disconnect_qos1_test(Config) ->
     ok = gen_tcp:close(Socket1).
 
 publish_b2c_disconnect_qos2_test(Config) ->
-    ClientId = mqtt5_v4compat:groupify("pub-b2c-qos2-disco-test", Config),
+    ClientId = vmq_cth:ustr(Config) ++ "pub-b2c-qos2-disco-test",
     Connect = mqtt5_v4compat:gen_connect(ClientId,
                                  [{keepalive, 60}, {clean_session, false}], Config),
     Connack1 = mqtt5_v4compat:gen_connack(success, Config),
@@ -263,7 +263,7 @@ publish_b2c_retry_qos2_test(Config) ->
     ok = gen_tcp:close(Socket).
 
 publish_c2b_disconnect_qos2_test(Config) ->
-    ClientId = mqtt5_v4compat:groupify("pub-c2b-qos2-disco-test", Config),
+    ClientId = vmq_cth:ustr(Config) ++ "pub-c2b-qos2-disco-test",
     Connect = mqtt5_v4compat:gen_connect(ClientId,
                                          [{keepalive, 60}, {clean_session, false}], Config),
     Connack1 = mqtt5_v4compat:gen_connack(success, Config),


### PR DESCRIPTION
Also update README to reflect that QoS1/2 retries are now according to the MQTTv5 spec and no longer as in MQTTv4.