### PR TITLE
Implement retain as publish subscribe flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Currently supported features are:
 - Client to broker topic aliases.
 - Broker to client topic aliases.
 - Receive maximum flow control.
+- Subscription flag Retain as Published is implemented
 - MQTTv5 and older prototocols can be enabled at the same time (set
   `allowed_protocol_versions=3,4,5` on the listener to enable respectively MQTT
   v3.1, 3.1.1 and 5.0).
@@ -43,8 +44,7 @@ Currently supported features are:
 Currently known issues for MQTTv5 are:
 
 - Tracing (`vmq-admin trace`) doesn't yet support tracing MQTTv5 sessions.
-- New subscription flags (No Local, Retain as Published, Retain Handling) are
-  ignored and subscriptions therefore currently work as in MQTTv4.
+- The subscription flags No Local, Retain Handling are currently ignored.
 - The plugin hooks for MQTTv5 sessions doesn't yet handle the new MQTTv5
   features.
 - Subscriber IDs are not yet implemented.

--- a/apps/vmq_server/src/vmq_cluster_com.erl
+++ b/apps/vmq_server/src/vmq_cluster_com.erl
@@ -192,8 +192,8 @@ process(<<Cmd:3/binary, L:32, _:L/binary, Rest/binary>>, St) ->
     lager:warning("unknown message: ~p", [Cmd]),
     process(Rest, St).
 
-publish({_, _} = SubscriberIdAndQoS, Msg) ->
-    vmq_reg:publish(SubscriberIdAndQoS, Msg);
+publish({_, _} = SubscriberIdAndSubInfo, Msg) ->
+    vmq_reg:publish(SubscriberIdAndSubInfo, Msg);
 publish(_Node, Msg) ->
     %% we ignore remote subscriptions, they are already covered
     %% by original publisher

--- a/apps/vmq_server/src/vmq_mqtt_fsm.erl
+++ b/apps/vmq_server/src/vmq_mqtt_fsm.erl
@@ -346,7 +346,8 @@ connected(#mqtt_subscribe{message_id=MessageId, topics=Topics}, State) ->
     _ = vmq_metrics:incr_mqtt_subscribe_received(),
     OnAuthSuccess =
         fun(_User, _SubscriberId, MaybeChangedTopics) ->
-                case vmq_reg:subscribe(CAPSettings#cap_settings.allow_subscribe, SubscriberId, MaybeChangedTopics) of
+                SubTopics = vmq_mqtt_fsm_util:to_vmq_subtopics(MaybeChangedTopics),
+                case vmq_reg:subscribe(CAPSettings#cap_settings.allow_subscribe, SubscriberId, SubTopics) of
                     {ok, _} = Res ->
                         vmq_plugin:all(on_subscribe, [User, SubscriberId, MaybeChangedTopics]),
                         Res;

--- a/apps/vmq_server/src/vmq_mqtt_fsm_util.erl
+++ b/apps/vmq_server/src/vmq_mqtt_fsm_util.erl
@@ -14,11 +14,14 @@
 
 -module(vmq_mqtt_fsm_util).
 -include("vmq_server.hrl").
+-include_lib("vmq_commons/include/vmq_types.hrl").
+-include_lib("vmq_commons/include/vmq_types_mqtt5.hrl").
 
 -export([send/2,
          send_after/2,
          msg_ref/0,
-         plugin_receive_loop/2]).
+         plugin_receive_loop/2,
+         to_vmq_subtopics/1]).
 
 -define(TO_SESSION, to_session_fsm).
 
@@ -81,3 +84,15 @@ plugin_receive_loop(PluginPid, PluginMod) ->
         Other ->
             exit({unknown_msg_in_plugin_loop, Other})
     end.
+
+-spec to_vmq_subtopics([mqtt5_subscribe_topic() | {topic(),qos()}]) -> [subscription()].
+to_vmq_subtopics(Topics) ->
+    lists:map(
+      fun({T, QoS}) ->
+              %% MQTTv4 style topics
+              {T, QoS};
+         (#mqtt5_subscribe_topic{
+             topic = T, qos = QoS, rap = Rap, retain_handling = RH, no_local = NL
+            }) ->
+              {T, {QoS, #{rap => Rap, retain_handling => RH, no_local => NL}}}
+      end, Topics).

--- a/apps/vmq_server/src/vmq_plugin_compat_v1_v0.erl
+++ b/apps/vmq_server/src/vmq_plugin_compat_v1_v0.erl
@@ -20,5 +20,13 @@
 
 -export([convert/4]).
 
+convert(auth_on_subscribe, Mod, Fun, [Username, SubscriberId, Topics]) ->
+    apply(Mod, Fun, [Username, SubscriberId, topics_v1_v0(Topics)]);
 convert(_, Mod, Fun, Args) ->
     apply(Mod, Fun, Args).
+
+topics_v1_v0(Topics) ->
+    lists:map(
+      fun({T, {QoS, _SubOpts}}) ->
+              {T, QoS}
+      end, Topics).

--- a/apps/vmq_server/src/vmq_reg.erl
+++ b/apps/vmq_server/src/vmq_reg.erl
@@ -620,7 +620,7 @@ fold_subscribers(FoldFun, Acc) ->
       end, Acc).
 
 -spec add_subscriber([{topic(), qos() | not_allowed} |
-                      {topic(), qos() | not_allowed, map()}], subscriber_id()) -> ok.
+                      {topic(), {qos() | not_allowed, map()}}], subscriber_id()) -> ok.
 add_subscriber(Topics, SubscriberId) ->
     OldSubs = subscriptions_for_subscriber_id(SubscriberId),
     NewSubs =

--- a/apps/vmq_server/src/vmq_reg_trie.erl
+++ b/apps/vmq_server/src/vmq_reg_trie.erl
@@ -228,26 +228,26 @@ handle_event(Handler, Event) ->
             ok
     end.
 
-handle_add_event({[<<"$share">>, Group|Topic], QoS, Node}, {MP, _} = SubscriberId) ->
+handle_add_event({[<<"$share">>, Group|Topic], SubInfo, Node}, {MP, _} = SubscriberId) ->
     add_complex_topic(MP, Topic, {Node, Group}, true),
-    add_subscriber_group(MP, Node, Group, Topic, SubscriberId, QoS),
+    add_subscriber_group(MP, Node, Group, Topic, SubscriberId, SubInfo),
     SubscriberId;
-handle_add_event({Topic, QoS, Node}, {MP, _} = SubscriberId) when Node == node() ->
+handle_add_event({Topic, SubInfo, Node}, {MP, _} = SubscriberId) when Node == node() ->
     add_complex_topic(MP, Topic, Node, vmq_topic:contains_wildcard(Topic)),
-    add_subscriber(MP, Topic, SubscriberId, QoS),
+    add_subscriber(MP, Topic, SubscriberId, SubInfo),
     SubscriberId;
 handle_add_event({Topic, _, Node}, {MP, _} = SubscriberId) ->
     add_complex_topic(MP, Topic, Node, vmq_topic:contains_wildcard(Topic)),
     add_remote_subscriber(MP, Topic, Node),
     SubscriberId.
 
-handle_delete_event({[<<"$share">>, Group|Topic], QoS, Node}, {MP, _} = SubscriberId) ->
+handle_delete_event({[<<"$share">>, Group|Topic], SubInfo, Node}, {MP, _} = SubscriberId) ->
     del_complex_topic(MP, Topic, {Node, Group}, true),
-    del_subscriber_group(MP, Node, Group, Topic, SubscriberId, QoS),
+    del_subscriber_group(MP, Node, Group, Topic, SubscriberId, SubInfo),
     SubscriberId;
-handle_delete_event({Topic, QoS, Node}, {MP, _} = SubscriberId) when Node == node() ->
+handle_delete_event({Topic, SubInfo, Node}, {MP, _} = SubscriberId) when Node == node() ->
     del_complex_topic(MP, Topic, Node, vmq_topic:contains_wildcard(Topic)),
-    del_subscriber(MP, Topic, SubscriberId, QoS),
+    del_subscriber(MP, Topic, SubscriberId, SubInfo),
     SubscriberId;
 handle_delete_event({Topic, _, Node}, {MP, _} = SubscriberId) ->
     del_complex_topic(MP, Topic, Node, vmq_topic:contains_wildcard(Topic)),
@@ -280,15 +280,15 @@ match_(Topic, [{NodeOrGroup,_}|Rest], Acc) ->
     match_(Topic, Rest, [{Topic, NodeOrGroup}|Acc]);
 match_(_, [], Acc) -> Acc.
 
-initialize_trie({MP, [<<"$share">>,Group|Topic], {SubscriberId, QoS, Node}}, Acc) ->
+initialize_trie({MP, [<<"$share">>,Group|Topic], {SubscriberId, SubInfo, Node}}, Acc) ->
     add_complex_topic(MP, Topic, {Node, Group}, true),
-    add_subscriber_group(MP, Node, Group, Topic, SubscriberId, QoS),
+    add_subscriber_group(MP, Node, Group, Topic, SubscriberId, SubInfo),
     Acc;
-initialize_trie({MP, Topic, {SubscriberId, QoS, Node}}, Acc) when Node =:= node() ->
+initialize_trie({MP, Topic, {SubscriberId, SubInfo, Node}}, Acc) when Node =:= node() ->
     add_complex_topic(MP, Topic, Node, vmq_topic:contains_wildcard(Topic)),
-    add_subscriber(MP, Topic, SubscriberId, QoS),
+    add_subscriber(MP, Topic, SubscriberId, SubInfo),
     Acc;
-initialize_trie({MP, Topic, {_SubscriberId, _QoS, Node}}, Acc)  ->
+initialize_trie({MP, Topic, {_SubscriberId, _SubInfo, Node}}, Acc)  ->
     add_complex_topic(MP, Topic, Node, vmq_topic:contains_wildcard(Topic)),
     add_remote_subscriber(MP, Topic, Node),
     Acc.

--- a/apps/vmq_server/src/vmq_server.hrl
+++ b/apps/vmq_server/src/vmq_server.hrl
@@ -25,6 +25,10 @@
          }).
 -type msg()             :: #vmq_msg{}.
 
+-type subopts() :: map().
+-type subinfo() :: qos() | {qos(), subopts()}.
+-type subscription() :: {topic(), subinfo()}.
+
 %% TODO: these definitions should probably be moved somewhere else.
 -define(NOT_AUTHORIZED,           not_authorized).
 -define(SESSION_TAKEN_OVER,       session_taken_over).

--- a/apps/vmq_server/src/vmq_subscriber.erl
+++ b/apps/vmq_server/src/vmq_subscriber.erl
@@ -174,17 +174,13 @@ get_node_subs(Node, Subs) ->
 fold(Fun, Acc, Subs) ->
     lists:foldl(fun({Node, _, NSubs}, AccAcc) ->
                         lists:foldl(
-                          fun({Topic, QoS}, AccAccAcc) ->
-                                  Fun({Topic, QoS, Node}, AccAccAcc);
-                             ({Topic, QoS, Opts}, AccAccAcc) ->
-                                  Fun({Topic, {QoS, Opts}, Node}, AccAccAcc)
+                          fun({Topic, SubInfo}, AccAccAcc) ->
+                                  Fun({Topic, SubInfo, Node}, AccAccAcc)
                           end, AccAcc, NSubs);
                    ({Node, NChanges}, AccAcc) ->
                         lists:foldl(
-                          fun({Topic, QoS}, AccAccAcc) ->
-                                  Fun({Topic, QoS, Node}, AccAccAcc);
-                             ({Topic, QoS, Opts}, AccAccAcc) ->
-                                  Fun({Topic, {QoS, Opts}, Node}, AccAccAcc)
+                          fun({Topic, SubInfo}, AccAccAcc) ->
+                                  Fun({Topic, SubInfo, Node}, AccAccAcc)
                           end, AccAcc, NChanges)
                 end, Acc, Subs).
 

--- a/apps/vmq_server/test/vmq_cluster_SUITE.erl
+++ b/apps/vmq_server/test/vmq_cluster_SUITE.erl
@@ -867,7 +867,7 @@ publish_random(Nodes, N, Topic, Acc) ->
 receive_publishes(_, _, []) -> ok;
 receive_publishes([{_,Port}=N|Nodes], Topic, Payloads) ->
     Connect = packet:gen_connect("connect-unclean", [{clean_session, false},
-                                                           {keepalive, 10}]),
+                                                     {keepalive, 10}]),
     Connack = packet:gen_connack(true, 0),
     Opts = [{port, Port}],
     {ok, Socket} = packet:do_client_connect(Connect, Connack, Opts),

--- a/apps/vmq_server/test/vmq_subscribe_SUITE.erl
+++ b/apps/vmq_server/test/vmq_subscribe_SUITE.erl
@@ -51,8 +51,6 @@ groups() ->
      {mqttv5, [shuffle],
       [
        subscribe_no_local_test,
-       subscribe_retain_as_published_test,
-       subscribe_retain_handling_flags_test,
        subscribe_illegal_opt
       ]}
     ].
@@ -67,39 +65,6 @@ subscribe_no_local_test(_) ->
     %% option. If the value is 1, Application Messages MUST NOT be
     %% forwarded to a connection with a ClientID equal to the ClientID
     %% of the publishing connection [MQTT-3.8.3-3].
-    {skip, not_implemented}.
-
-subscribe_retain_as_published_test(_) ->
-    %% maybe move to the retain suite?
-
-    %% Bit 3 of the Subscription Options represents the Retain As
-    %% Published option. If 1, Application Messages forwarded using
-    %% this subscription keep the RETAIN flag they were published
-    %% with. If 0, Application Messages forwarded using this
-    %% subscription have the RETAIN flag set to 0. Retained messages
-    %% sent when the subscription is established have the RETAIN flag
-    %% set to 1.
-    {skip, not_implemented}.
-
-subscribe_retain_handling_flags_test(_) ->
-    %% maybe move to the retain suite?
-
-    %% Bits 4 and 5 of the Subscription Options represent the Retain
-    %% Handling option. This option specifies whether retained
-    %% messages are sent when the subscription is established. This
-    %% does not affect the sending of retained messages at any point
-    %% after the subscribe. If there are no retained messages matching
-    %% the Topic Filter, all of these values act the same. The values
-    %% are:
-    %%
-    %% 0 = Send retained messages at the time of the subscribe
-    %%
-    %% 1 = Send retained messages at subscribe only if the
-    %% subscription does not currently exist
-    %%
-    %% 2 = Do not send retained messages at the time of the subscribe
-    %%
-    %% It is a Protocol Error to send a Retain Handling value of 3.
     {skip, not_implemented}.
 
 subscribe_illegal_opt(_) ->


### PR DESCRIPTION
This is the first part of implementing the subscription options and this implements the Retain as Publish flag.

Currently working on implementing the 'no local' and 'retain handling' flags, but I though it would be nice to review this first as it's already quite large as is and touches a lot of different places in the code base.

