### PR TITLE
Fix vmq_passwd build issue on OSX

### DIFF
--- a/apps/vmq_passwd/c_src/Makefile
+++ b/apps/vmq_passwd/c_src/Makefile
@@ -1,4 +1,13 @@
-CC?=	gcc
+CC? = gcc
+CFLAGS_EXTRA =
+
+ifeq ($(shell uname -s), Darwin)
+	# OSX with homebrew
+	OPENSSL_DIR ?= /usr/local/opt/openssl
+	CFLAGS_EXTRA += -L${OPENSSL_DIR}/lib -I${OPENSSL_DIR}/include
+endif
+
+all: compile
 
 compile:
-	$(CC) $(CFLAGS) vmq_passwd.c -lcrypto -o ../priv/vmq_passwd
+	$(CC) $(CFLAGS) $(CFLAGS_EXTRA) vmq_passwd.c -lcrypto -o ../priv/vmq_passwd

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ## Not yet released (VerneMQ 1.4.0)
 
+- Fix for OSX compilation issue on `vmq_passwd` due to openssl headers not found.
 - Small refactoring moving the calling of plugin hooks into the fsm code. This
   is a preparation for MQTTv5. Note, this change has an impact on the
   `vmq_reg:direct_plugin_exports/1` function. Even though this function is


### PR DESCRIPTION
Very small change that fixes the compilation issue on OSX. Fix for # 119, second part coming soon to build the homebrew package.