### PR TITLE
Include other libraries from the Erlang standard library in the release

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -54,6 +54,8 @@
   loaded.
 - Fix issue with new rebar3 upstream plugin version (the port-compiler) which
   made builds fail by pegging it to an older version (1.8.0).
+- Add `xmerl` and `inets` from the Erlang standard library to the release in order
+  to allow plugin developers to have these libraries available.
 
 ## VerneMQ 1.3.0
 

--- a/rebar.config
+++ b/rebar.config
@@ -71,6 +71,8 @@
  [{release, {vernemq, "1.3.0"},
    [
     sasl,
+    inets,
+    xmerl,
     vmq_server,
     vernemq_dev,
     {cuttlefish, load},


### PR DESCRIPTION
This is related to #696. Will be nice to have a discussion here to see what other libraries from the stdlib can be included that can help plugin development. Only libraries that others usually depend on and can be only obtained from the stdlib.

@dergraf @larshesel  ^^