### PR TITLE
Peg bcrypt port compiler version

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -51,7 +51,9 @@
 - Small refactoring enabling to store versioned message store values. This is a
   preparation for MQTTv5.
 - Bugfix: Fix a bug that prevented user plugins with an explicit path to be
-  loaded
+  loaded.
+- Fix issue with new rebar3 upstream plugin version (the port-compiler) which
+  made builds fail by pegging it to an older version (1.8.0).
 
 ## VerneMQ 1.3.0
 

--- a/rebar.config
+++ b/rebar.config
@@ -31,6 +31,13 @@
                {post_hooks,
                 [{"(linux|darwin|solaris)", clean, "make -C c_src clean"},
                  {"(freebsd)", clean, "gmake -C c_src clean"}]}
+              ]},
+             {override, bcrypt,
+              [
+               %% Pegging the pc (port-compiler) to a known working
+               %% version as newer (v1.9.1) doesn't seem to work. See
+               %% https://github.com/blt/port_compiler/issues/48.
+               {plugins, [{pc, "1.8.0"}]}
               ]}
             ]}.
 


### PR DESCRIPTION
A workaround for https://github.com/blt/port_compiler/issues/48