### PR TITLE
Load the observer that contains etop with the release

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -62,6 +62,8 @@
   graphite api key from being set in the `vernemq.conf` file.
 - Bugfix: WebHooks Plugin. Close the Hackney CRef so that the socket is given
   back to the Hackney pool, for the case of non-200 HTTP OK status codes.
+- Bugfix: Fix `vernemq top` command(like Erlang's etop) for presenting information
+  about node processes (#661).
 
 ## VerneMQ 1.3.0
 

--- a/rebar.config
+++ b/rebar.config
@@ -87,6 +87,7 @@
     {syslog, load},
     {lager_syslog, load},
     {runtime_tools, load},
+    {observer, load},
     {tools, load},
     {mcd, load}
    ]},


### PR DESCRIPTION
This is the fix for #661, accompanying Pull request was submitted the `node_package` repository at https://github.com/erlio/node_package/pull/1. Already tested and working great locally.