### PR TITLE
RFC - Generalize metrics

### DIFF
--- a/apps/vmq_server/priv/vmq_server.schema
+++ b/apps/vmq_server/priv/vmq_server.schema
@@ -1382,6 +1382,12 @@
                                                               {datatype, string}
                                                              ]}.
 
+%% @doc genenerate extra metrics from metrics with labels.
+{mapping, "graphite_include_labels", "vmq_server.graphite_include_labels", [
+                                                                            {default, off},
+                                                                            {datatype, flag},
+                                                                            hidden
+                                                                           ]}.
 
 {mapping, "leveldb_message_store.directory", "vmq_server.msg_store_opts.store_dir", [
                                                                             {default, "{{platform_data_dir}}/msgstore"},

--- a/apps/vmq_server/src/vmq_config_cli.erl
+++ b/apps/vmq_server/src/vmq_config_cli.erl
@@ -49,6 +49,7 @@ register_config_() ->
      "graphite_host",
      "graphite_port",
      "graphite_interval",
+     "graphite_include_labels",
      "shared_subscription_policy",
      "remote_enqueue_timeout",
      "suppress_lwt_on_session_takeover"

--- a/apps/vmq_server/src/vmq_graphite.erl
+++ b/apps/vmq_server/src/vmq_graphite.erl
@@ -17,6 +17,8 @@
 
 -behaviour(gen_server).
 
+-include_lib("vmq_metrics.hrl").
+
 %% API
 -export([start_link/0]).
 
@@ -34,6 +36,7 @@
 -define(DEFAULT_CONNECT_TIMEOUT, 5000).
 -define(DEFAULT_RECONNECT_TIMEOUT, 2000).
 -define(DEFAULT_INTERVAL, 20000).
+-define(DEFAULT_INCLUDE_LABELS, false).
 
 %% calendar:datetime_to_gregorian_seconds({{1970,1,1},{0,0,0}}).
 -define(UNIX_EPOCH, 62167219200).
@@ -146,34 +149,41 @@ handle_info(timeout, Socket) ->
             gen_tcp:close(Socket),
             {noreply, undefined, 5000};
          true ->
-             ApiKey = vmq_config:get_env(graphite_api_key, ""),
-             Prefix = vmq_config:get_env(graphite_prefix, ""),
-             DoReconnect =
-             lists:foldl(
-               fun (_, true) ->
-                       %% error occured
-                       true;
-                   ({_Type, Metric, Val}, false) ->
-                       Line = [key(ApiKey, Prefix, Metric), " ",
-                               value(Val), " ", timestamp(), $\n],
-                       case gen_tcp:send(Socket, Line) of
-                           ok ->
-                               false;
-                           {error, _} ->
-                               true
-                       end
-               end, false, vmq_metrics:metrics()),
-             case DoReconnect of
-                 true ->
-                     gen_tcp:close(Socket),
-                     ReconnectTimeout =
-                     vmq_config:get_env(graphite_reconnect_timeout, ?DEFAULT_RECONNECT_TIMEOUT),
-                     {noreply, undefined, ReconnectTimeout};
-                 false ->
-                     Interval = vmq_config:get_env(graphite_interval, ?DEFAULT_INTERVAL),
-                     {noreply, Socket, Interval}
-             end
+            ApiKey = vmq_config:get_env(graphite_api_key, ""),
+            Prefix = vmq_config:get_env(graphite_prefix, ""),
+            IncludeLabels = vmq_config:get_env(graphite_include_labels, ?DEFAULT_INCLUDE_LABELS),
+            DoReconnect =
+                lists:foldl(
+                  fun (_, true) ->
+                          %% error occured
+                          true;
+                      ({#metric_def{name = Metric, labels = Labels}, Val}, false) ->
+                          Lines =
+                          case IncludeLabels of
+                              true ->
+                                  lines(ApiKey, Prefix, Metric, Labels, Val);
+                              false ->
+                                  lines(ApiKey, Prefix, Metric, Val)
+                          end,
+                          case gen_tcp:send(Socket, Lines) of
+                              ok ->
+                                  false;
+                              {error, _} ->
+                                  true
+                          end
+                  end, false, vmq_metrics:metrics()),
+            case DoReconnect of
+                true ->
+                    gen_tcp:close(Socket),
+                    ReconnectTimeout =
+                        vmq_config:get_env(graphite_reconnect_timeout, ?DEFAULT_RECONNECT_TIMEOUT),
+                    {noreply, undefined, ReconnectTimeout};
+                false ->
+                    Interval = vmq_config:get_env(graphite_interval, ?DEFAULT_INTERVAL),
+                    {noreply, Socket, Interval}
+            end
      end.
+
 %%--------------------------------------------------------------------
 %% @private
 %% @doc
@@ -203,7 +213,23 @@ code_change(_OldVsn, State, _Extra) ->
 %%% Internal functions
 %%%===================================================================
 
-%% Format a graphite key from API key, prefix, prob and datapoint
+%% Format a graphite key from API key, prefix, prob, labels and datapoint
+lines(APIKey, Prefix, Metric, Val) ->
+    line(APIKey, Prefix, Metric, no_label, Val).
+
+lines(APIKey, Prefix, Metric, Labels, Val) ->
+    %% Always generate the metric with no labels
+    [line(APIKey, Prefix, Metric, no_label, Val)
+     |[line(APIKey, Prefix, Metric, Label, Val) || Label <- Labels]].
+
+line(APIKey, Prefix, Metric, Label, Val) ->
+    [key(APIKey, Prefix, Metric, Label), " ", value(Val), " ", timestamp(), $\n].
+
+key(APIKey, Prefix, Metric, no_label) ->
+    key(APIKey, Prefix, Metric);
+key(APIKey, Prefix, Metric, {Key, Val}) ->
+    [key(APIKey, Prefix, Metric), $., atom_to_list(Key), $_, Val].
+
 key([], [], Metric) ->
     name(Metric);
 key([], Prefix, Metric) ->

--- a/apps/vmq_server/src/vmq_metrics.hrl
+++ b/apps/vmq_server/src/vmq_metrics.hrl
@@ -1,0 +1,14 @@
+
+-type metric_label() :: {atom(), string()}.
+
+-type metric_id() :: atom().
+
+-record(metric_def,
+        {type        :: atom(),
+         labels      :: [metric_label()],
+         id          :: metric_id(),
+         name        :: atom(),
+         description :: undefined | binary()}).
+-type metric_def() :: #metric_def{}.
+
+-type metric_val() :: {Def :: metric_def(), Val :: any()}.

--- a/apps/vmq_server/src/vmq_server_app.erl
+++ b/apps/vmq_server/src/vmq_server_app.erl
@@ -27,7 +27,6 @@
 start(_StartType, _StartArgs) ->
     ok = vmq_metadata:start(),
 
-    vmq_server_cli:init_registry(),
     case vmq_server_sup:start_link() of
         {error, _} = E ->
             E;
@@ -37,6 +36,7 @@ start(_StartType, _StartArgs) ->
             %% vmq_plugin_mgr waits for the 'vmq_server_sup' process
             %% to be registered.
             timer:sleep(500),
+            vmq_server_cli:init_registry(),
             start_user_plugins(),
             vmq_config:configure_node(),
             R

--- a/apps/vmq_server/src/vmq_systree.erl
+++ b/apps/vmq_server/src/vmq_systree.erl
@@ -17,6 +17,8 @@
 
 -behaviour(gen_server).
 
+-include("vmq_metrics.hrl").
+
 %% API
 -export([start_link/0]).
 
@@ -123,7 +125,7 @@ handle_info(timeout, true) ->
                          sg_policy=vmq_config:get_env(shared_subscription_policy, prefer_local)
                         },
             lists:foreach(
-              fun({_Type, Metric, Val}) ->
+              fun({#metric_def{name=Metric}, Val}) ->
                       CAPPublish = true,
                       vmq_reg:publish(CAPPublish, RegView, MsgTmpl#vmq_msg{
                                         routing_key=key(Prefix, Metric),

--- a/apps/vmq_server/test/vmq_metrics_SUITE.erl
+++ b/apps/vmq_server/test/vmq_metrics_SUITE.erl
@@ -11,8 +11,7 @@
 -export([simple_systree_test/1,
          simple_graphite_test/1,
          simple_prometheus_test/1,
-         simple_cli_test/1,
-         all_metrics_have_descriptions/1]).
+         simple_cli_test/1]).
 
 -export([hook_auth_on_subscribe/3]).
 
@@ -27,6 +26,7 @@ init_per_testcase(_Case, Config) ->
     vmq_test_utils:setup(),
     enable_on_subscribe(),
     vmq_server_cmd:set_config(allow_anonymous, true),
+    vmq_server_cmd:set_config(graphite_interval, 100),
     vmq_server_cmd:set_config(retry_interval, 10),
     vmq_server_cmd:listener_start(1888, []),
     vmq_metrics:reset_counters(),
@@ -41,8 +41,7 @@ all() ->
     [simple_systree_test,
      simple_graphite_test,
      simple_prometheus_test,
-     simple_cli_test,
-     all_metrics_have_descriptions].
+     simple_cli_test].
 
 simple_systree_test(_) ->
     Socket = sample_subscribe(),
@@ -55,29 +54,55 @@ simple_graphite_test(_) ->
     vmq_server_cmd:set_config(graphite_enabled, true),
     vmq_server_cmd:set_config(graphite_host, "localhost"),
     vmq_server_cmd:set_config(graphite_interval, 1000),
+    vmq_server_cmd:set_config(graphite_include_labels, false),
     SubSocket = sample_subscribe(),
     {ok, LSocket} = gen_tcp:listen(2003, [binary, {packet, raw},
                                           {active, false},
                                           {reuseaddr, true}]),
-    {ok, GraphiteSocket} = gen_tcp:accept(LSocket), %% vmq_graphite connects
-    true = recv_data(GraphiteSocket),
+    {ok, GraphiteSocket1} = gen_tcp:accept(LSocket), %% vmq_graphite connects
+    Want = [<<"mqtt.subscribe.received 1">>],
+    true = recv_data(GraphiteSocket1, Want),
+    gen_tcp:close(GraphiteSocket1),
+
+    vmq_server_cmd:set_config(graphite_include_labels, true),
+    {ok, GraphiteSocket2} = gen_tcp:accept(LSocket), %% vmq_graphite connects
+    WantLabels = [<<"mqtt.subscribe.received 1">>,
+                  <<"mqtt.subscribe.received.mqtt_version_4 1">>],
+    true = recv_data(GraphiteSocket2, WantLabels),
+
     gen_tcp:close(SubSocket),
-    gen_tcp:close(GraphiteSocket),
+    gen_tcp:close(GraphiteSocket2),
     gen_tcp:close(LSocket).
 
-recv_data(Socket) ->
-    case gen_tcp:recv(Socket, 0) of
-        {ok, Data} ->
-            Ret =
-            lists:foldl(fun(<<"mqtt.subscribe.received 1", _/binary>>, _) ->
-                                true;
-                           (_, Acc) ->
-                                Acc
-                        end, false, re:split(Data, "\n")),
-            case Ret of
-                true -> true;
-                false ->
-                    recv_data(Socket)
+recv_data(Socket, Want0) ->
+    case gen_tcp:recv(Socket, 0, 5000) of
+        {ok, Data0} ->
+            %% split in lines and remove trailing timestamps
+            Data1 = lists:map(
+                      fun(<<>>) -> <<>>;
+                         (Line) ->
+                              case re:split(Line, " ") of
+                                  [Key, Val, _Timestamp] ->
+                                      <<Key/binary, " ", Val/binary>>;
+                                  _ ->
+                                      %% probably received a partial line,
+                                      %% ignore it and hope we get it next time
+                                      <<>>
+                              end
+                      end,
+                      re:split(Data0, "\n")),
+            Want1 =
+            lists:foldl(
+              fun(Line, WantAcc) ->
+                      case lists:member(Line, WantAcc) of
+                          true -> WantAcc -- [Line];
+                          false -> WantAcc
+                      end
+              end, Want0, Data1),
+            case Want1 of
+                [] -> true;
+                _ ->
+                    recv_data(Socket, Want1)
             end
     end.
 
@@ -92,7 +117,8 @@ simple_prometheus_test(_) ->
     {ok, {_Status, _Headers, Body}} = httpc:request("http://localhost:8888/metrics"),
     Lines = re:split(Body, "\n"),
     Node = atom_to_list(node()),
-    Line = list_to_binary("mqtt_subscribe_received{node=\"" ++ Node ++ "\"} 1"),
+    Line = list_to_binary(
+             "mqtt_subscribe_received{node=\"" ++ Node ++ "\",mqtt_version=\"4\"} 1"),
     true = lists:foldl(fun(L, _) when L == Line ->
                                true;
                           (_, Acc) -> Acc
@@ -107,11 +133,6 @@ simple_cli_test(_) ->
                    (_, Acc) -> Acc
                 end, false, Ret),
     gen_tcp:close(SubSocket).
-
-all_metrics_have_descriptions(_) ->
-    %% This will retrieve all metrics with descriptions and blow up if
-    %% some are missing.
-    _ = vmq_metrics:metrics(true).
 
 enable_on_subscribe() ->
     vmq_plugin_mgr:enable_module_plugin(

--- a/apps/vmq_server/test/vmq_publish_SUITE.erl
+++ b/apps/vmq_server/test/vmq_publish_SUITE.erl
@@ -3,6 +3,8 @@
 -compile(export_all).
 -compile(nowarn_export_all).
 
+-include("../src/vmq_metrics.hrl").
+
 %% ===================================================================
 %% common_test callbacks
 %% ===================================================================
@@ -435,7 +437,12 @@ message_size_exceeded_close(_) ->
     enable_on_publish(),
     ok = gen_tcp:send(Socket, Publish),
     {error, closed} = gen_tcp:recv(Socket, 0, 1000),
-    true = lists:member({counter, mqtt_invalid_msg_size_error, 1}, vmq_metrics:metrics()),
+    true = lists:any(
+             fun({#metric_def{
+                     type = counter,
+                     id = mqtt_invalid_msg_size_error}, 1}) -> true;
+                (_) -> false
+             end,vmq_metrics:metrics()),
     vmq_config:set_env(max_message_size, OldLimit, false),
     disable_on_publish().
 

--- a/changelog.md
+++ b/changelog.md
@@ -27,6 +27,13 @@
   hash from which the package was built and `10` is the number of commits since
   the latest tag. This makes it much easier to reason about nightly builds and
   the features they contain.
+- Refactor and generalize the metrics systems to allow labelling metrics coming
+  from different sources in order to differentiate them in the various exporters
+  and the command line. Labels are added to the Prometheus exporter by
+  default. To enable generating additional metrics from the labels in the
+  graphite exporter the hidden setting `graphite_include_labels` has to be set
+  to `on` in the `vernemq.conf` file. Labels are not exposed in the $SYS
+  metrics.
 
 ## VerneMQ 1.4.0
 


### PR DESCRIPTION
   The purpose of this PR is to generalize the metrics system in a way
   such that we can:

   1. Have metrics with the same conceptual name, but still be able to
      distinguish them via tags describing for example a
      context. Example: `mqtt_publish_received` for MQTT 5 and MQTT
      3.1.1 - one should be able to ask for any mqtt publish messages
      received or just for the ones relevant for a specific protocol
      version.

   2. Metrics with the same conceptual name but different tags are
      aggregated (summarized) if no specific tag was requested.

   3. It is possible to retrieve all metrics without aggregations
      applied. In this case tag information will also be delivered to
      the receiver. Unaggregated metrics is required for monitoring
      systems like Prometheus where it should be possible to do the
      aggregation manually or only inspect events belonging to a
      specific tag if desired.

   4. Some metrics cannot be aggregated via summation due to their
      nature. One example are the scheduler utilization gauges as
      these are averages over time. Of course these are unique and
      have different conceptual names
      (`system_utilization_scheduler_1`,
      `system_utilization_scheduler_2`) and as such will not be
      summarized. In general metrics which should never be aggregated
      need to have unique conceptual names!

   5. Other kinds of aggregation than summation could be
      constructed. For instance instead of summarizing some kind of
      general function could be calculated over the metrics in
      question. For example an average could be used: instead of
      getting the total number of `mqtt_publish_received` events for
      all tags, one could calculate the average instead. It's not
      clear what the benefit would be here and as no obvious examples
      were thought of only aggregation via summation is used. It
      should also be mentioned that these other aggregation mechanism
      can also be applied later, for instance using a monitoring
      system like Prometheus.

Todos:

- [x] add tag support to the cli
- [x] provide tag information to the prometheus exporter
- [x] provide tag information to the grafana exporter
- [x] provide tag information to the $SYSTREE exporter
- [x] create a metrics manager process where we can register used tags and register new metrics (and it can be checked if it already exists)