### PR TITLE
Handle case where there is nothing to serialize

### DIFF
--- a/apps/vmq_server/src/vmq_mqtt_pre_init.erl
+++ b/apps/vmq_server/src/vmq_mqtt_pre_init.erl
@@ -112,8 +112,10 @@ msg_in(close_timeout, _FsmState0) ->
     lager:debug("stop due to timeout", []),
     {stop, normal, []}.
 
+serialize([]) -> [];
 serialize([Out]) ->
     [vmq_parser:serialise(Out)].
 
+serialize_mqtt5([]) -> [];
 serialize_mqtt5([Out]) ->
     [vmq_parser_mqtt5:serialise(Out)].


### PR DESCRIPTION
This can happen in the pre_init stage if we terminate the connection
instead of sending a connack.