### PR TITLE
Gracefully convert new `vmq_msg` records to internal known format

### DIFF
--- a/apps/vmq_server/test/vmq_retain_SUITE.erl
+++ b/apps/vmq_server/test/vmq_retain_SUITE.erl
@@ -41,7 +41,8 @@ groups() ->
          retain_qos0_clear_test,
          retain_qos1_qos0_test,
          retain_wildcard_test,
-         publish_empty_retained_msg_test],
+         publish_empty_retained_msg_test,
+         retain_compat_pre_test],
     [
      {mqtt, [shuffle, parallel], Tests}
     ].
@@ -181,6 +182,13 @@ retain_wildcard_test(_) ->
     ok = packet:expect_packet(Socket, "suback", Suback),
     ok = packet:expect_packet(Socket, "publish", Publish),
     ok = gen_tcp:close(Socket).
+
+retain_compat_pre_test(_Cfg) ->
+    Pre = <<"msg">>,
+    Pre = vmq_reg:retain_pre(Pre),
+
+    Future = {retain_msg, 1, <<"future_msg">>, something, else},
+    <<"future_msg">> = vmq_reg:retain_pre(Future).
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%% Hooks

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,13 @@
   timeout (#726).
 - Fix issue with self referential cluster leaves and cluster readiness probing
   in general (#717).
+- Add preparations for MQTTv5:
+  - Make it possible to extend the cluster internal message format when adding
+    new features while ensuring back- and forwards compatibility.
+  - Refactor the leveldb message store code to support versioned indexes as well
+    as messages.
+  - Refactor the retained message store to support versions.
+  - Add support for subscriber data with subscription options.
 
 ## VerneMQ 1.4.0
 


### PR DESCRIPTION
Prepare VerneMQ to be able to handle:
- Cross cluster messages coming from a MQTTv5 enabled VerneMQ node
- Messages in the message store from a MQTTv5 node (downgrade)
- MQTTv5 Retained messages which are distributed via plumtree
- MQTTv5 Subscriber metadata which is distributed via plumtree