### PR TITLE
Fix readyness probe in a healthy cluster that has previously resolved a netsplit

### DIFF
--- a/apps/vmq_server/src/vmq_cluster.erl
+++ b/apps/vmq_server/src/vmq_cluster.erl
@@ -187,9 +187,9 @@ check_ready([], Acc) ->
     end,
     NewObj =
     case {all_nodes_alive(Acc), OldObj} of
-        {true, {true, 0, 0}} ->
-            % initial case, possibly single-node cluster
-            {true, 0, 0};
+        {true, {true, NetsplitDetectedCnt, NetsplitResolvedCnt}} ->
+            % Cluster was consistent, is still consistent
+            {true, NetsplitDetectedCnt, NetsplitResolvedCnt};
         {true, {false, NetsplitDetectedCnt, NetsplitResolvedCnt}} ->
             % Cluster was inconsistent, netsplit resolved
             {true, NetsplitDetectedCnt, NetsplitResolvedCnt + 1};


### PR DESCRIPTION
This PR fixes a case that was forgotten in #731, namely the readyness probe in a healthy cluster that has previously detected and resolved a netsplit.

No changelog item was added as this is covered by the item referenced in #731 and #717.