### PR TITLE
Fix QoS2 retry for reconnecting clients, and refactor and cleanup retry mechanism

### DIFF
--- a/apps/vmq_server/src/vmq_queue.erl
+++ b/apps/vmq_server/src/vmq_queue.erl
@@ -876,7 +876,7 @@ cleanup_queue(SId, Queue) ->
 cleanup_queue_(SId, {{value, {deliver, _, _} = Msg}, NewQueue}) ->
     maybe_offline_delete(SId, Msg),
     cleanup_queue_(SId, queue:out(NewQueue));
-cleanup_queue_(SId, {{value, {deliver_bin, _}}, NewQueue}) ->
+cleanup_queue_(SId, {{value, {deliver_pubrel, _}}, NewQueue}) ->
     % no need to deref
     cleanup_queue_(SId, queue:out(NewQueue));
 cleanup_queue_(SId, {{value, MsgRef}, NewQueue}) when is_binary(MsgRef) ->

--- a/apps/vmq_server/test/vmq_publish_SUITE.erl
+++ b/apps/vmq_server/test/vmq_publish_SUITE.erl
@@ -78,6 +78,7 @@ publish_qos1_test(_) ->
     ok = gen_tcp:send(Socket, Publish),
     ok = packet:expect_packet(Socket, "puback", Puback),
     disable_on_publish(),
+    ok = expect_alive(Socket),
     ok = gen_tcp:close(Socket).
 
 publish_qos2_test(_) ->
@@ -95,6 +96,7 @@ publish_qos2_test(_) ->
     ok = gen_tcp:send(Socket, Pubrel),
     ok = packet:expect_packet(Socket, "pubcomp", Pubcomp),
     disable_on_publish(),
+    ok = expect_alive(Socket),
     ok = gen_tcp:close(Socket).
 
 publish_b2c_disconnect_qos1_test(_) ->
@@ -112,6 +114,8 @@ publish_b2c_disconnect_qos1_test(_) ->
     Puback = packet:gen_puback(1),
     Publish2 = packet:gen_publish("qos1/outgoing", 1,
                                   <<"outgoing-message">>, [{mid, 3266}]),
+    Puback2 = packet:gen_puback(3266),
+
     enable_on_publish(),
     enable_on_subscribe(),
     {ok, Socket} = packet:do_client_connect(Connect, Connack1, []),
@@ -124,6 +128,8 @@ publish_b2c_disconnect_qos1_test(_) ->
     %% send our outgoing message, when we disconnect the broker
     %% should get rid of it and ssume we're going to retry
     ok = gen_tcp:send(Socket, Publish2),
+    ok = packet:expect_packet(Socket, "puback", Puback2),
+    ok = expect_alive(Socket),
     ok = gen_tcp:close(Socket),
     %% TODO: assert Publish2 deleted on broker
     %% reconnect
@@ -132,6 +138,7 @@ publish_b2c_disconnect_qos1_test(_) ->
     ok = gen_tcp:send(Socket1, Puback),
     disable_on_publish(),
     disable_on_subscribe(),
+    ok = expect_alive(Socket1),
     ok = gen_tcp:close(Socket1).
 
 publish_b2c_disconnect_qos2_test(_) ->
@@ -177,6 +184,7 @@ publish_b2c_disconnect_qos2_test(_) ->
     ok = gen_tcp:send(Socket2, Pubcomp),
     disable_on_publish(),
     disable_on_subscribe(),
+    ok = expect_alive(Socket2),
     ok = gen_tcp:close(Socket2).
 
 publish_b2c_timeout_qos1_test(_) ->
@@ -204,6 +212,7 @@ publish_b2c_timeout_qos1_test(_) ->
     ok = gen_tcp:send(Socket, Puback),
     disable_on_publish(),
     disable_on_subscribe(),
+    ok = expect_alive(Socket),
     ok = gen_tcp:close(Socket).
 
 publish_b2c_timeout_qos2_test(_) ->
@@ -237,6 +246,7 @@ publish_b2c_timeout_qos2_test(_) ->
     ok = gen_tcp:send(Socket, Pubcomp),
     disable_on_publish(),
     disable_on_subscribe(),
+    ok = expect_alive(Socket),
     ok = gen_tcp:close(Socket).
 
 publish_c2b_disconnect_qos2_test(_) ->
@@ -257,6 +267,7 @@ publish_c2b_disconnect_qos2_test(_) ->
     ok = gen_tcp:send(Socket, Publish),
     ok = packet:expect_packet(Socket, "pubrec", Pubrec),
     %% We're now going to disconnect and pretend we didn't receive the pubrec
+    ok = expect_alive(Socket),
     ok = gen_tcp:close(Socket),
     {ok, Socket1} = packet:do_client_connect(Connect, Connack2, []),
     ok = gen_tcp:send(Socket1, PublishDup),
@@ -264,11 +275,13 @@ publish_c2b_disconnect_qos2_test(_) ->
     ok = gen_tcp:send(Socket1, Pubrel),
     ok = packet:expect_packet(Socket1, "pubcomp", Pubcomp),
     %% Again, pretend we didn't receive this pubcomp
+    ok = expect_alive(Socket1),
     ok = gen_tcp:close(Socket1),
     {ok, Socket2} = packet:do_client_connect(Connect, Connack2, []),
     ok = gen_tcp:send(Socket2, Pubrel),
     ok = packet:expect_packet(Socket2, "pubcomp", Pubcomp),
     disable_on_publish(),
+    ok = expect_alive(Socket2),
     ok = gen_tcp:close(Socket2).
 
 publish_c2b_timeout_qos2_test(_) ->
@@ -286,6 +299,7 @@ publish_c2b_timeout_qos2_test(_) ->
     ok = gen_tcp:send(Socket, Pubrel),
     ok = packet:expect_packet(Socket, "pubcomp", Pubcomp),
     disable_on_publish(),
+    ok = expect_alive(Socket),
     ok = gen_tcp:close(Socket).
 
 pattern_matching_test(_) ->
@@ -563,3 +577,9 @@ helper_pattern_matching(PubTopic) ->
     ok = gen_tcp:send(Socket, Publish),
     ok = gen_tcp:send(Socket, packet:gen_disconnect()),
     gen_tcp:close(Socket).
+
+expect_alive(Socket) ->
+    Pingreq = packet:gen_pingreq(),
+    Pingresp = packet:gen_pingresp(),
+    ok = gen_tcp:send(Socket, Pingreq),
+    ok = packet:expect_packet(Socket, "pingresp", Pingresp).

--- a/changelog.md
+++ b/changelog.md
@@ -19,6 +19,8 @@
   existing session already exists for the connecting client. This is
   configurable via the hidden setting `suppress_lwt_on_session_takeover` in the
   VerneMQ configuration file. The default is `off`.
+- Fix issue with PUBREL frames retried after client reconnects (#762).
+- Refactor and cleanup retry mechanism.
 
 ## VerneMQ 1.4.0
 


### PR DESCRIPTION
- Store the *parsed* PUBREL inside the waiting acks instead of the
serialized binary.  This enables to reuse the same functionality for
handling retried PUBRELs, without caring if it is retried because of a
timeout or because of a reconnect. Cleanup places which relied on the
serialized binary.
- Fixing above enabled the possibility to implement a small performance
improvement where we could get rid of using `length()` on the outgoing
batch of frames for incrementing the `mqtt_publishes_sent` counter.
- Improved `vmq_publish_SUITE.erl` to test that a client responds to
PINGREQs before closing the Socket. This validates that 1st. the client
hasn't crashed in the meantime (e.g. because not being able to handle
the PUBCOMP, see bug #762), and 2nd that the last received frame on this
socket is the PINGRESP.
- The improvement above discovered an edgecase with a PUBREL frame that
has been retried too fast, indicating a bug in the retry mechanism. This
has been fixed with tagging the message IDs inside the retry queue. As a
result the retry mechanism can differentiate between retrying a PUBLISH
and a PUBREL. Without this fix a retried, already acked PUBLISH, would
have retried an unacked PUBREL right away.
- Removing several function clauses that were forgotten when fixing #750