### PR TITLE
Suppress lwt on session take over

### DIFF
--- a/apps/vmq_server/priv/vmq_server.schema
+++ b/apps/vmq_server/priv/vmq_server.schema
@@ -1449,6 +1449,15 @@
                                                    hidden
                                                   ]}.
 
+%% @doc Suppress the Last Will and Testament message if an existing
+%% session already exists for the connecting client.
+{mapping, "suppress_lwt_on_session_takeover",
+ "vmq_server.suppress_lwt_on_session_takeover", [
+                                                 {default, off},
+                                                 {datatype, flag},
+                                                 hidden
+                                                ]}.
+
 %% @doc plugins.<plugin> enables/disables a plugin.
 %%
 %% Plugin specific settings are set via the plugin itself, i.e., to

--- a/apps/vmq_server/src/vmq_config_cli.erl
+++ b/apps/vmq_server/src/vmq_config_cli.erl
@@ -50,7 +50,8 @@ register_config_() ->
      "graphite_port",
      "graphite_interval",
      "shared_subscription_policy",
-     "remote_enqueue_timeout"
+     "remote_enqueue_timeout",
+     "suppress_lwt_on_session_takeover"
     ],
     _ = [clique:register_config([Key], fun register_config_callback/3)
          || Key <- ConfigKeys],

--- a/apps/vmq_server/src/vmq_info_cli.erl
+++ b/apps/vmq_server/src/vmq_info_cli.erl
@@ -14,6 +14,8 @@
 
 -module(vmq_info_cli).
 
+-include("vmq_server.hrl").
+
 -export([register_cli/0]).
 
 register_cli() ->
@@ -101,7 +103,7 @@ vmq_session_disconnect_cmd() ->
                                vmq_ql_query_mgr:fold_query(
                                  fun(Row, _) ->
                                          QueuePid = maps:get(queue_pid, Row),
-                                         vmq_queue:force_disconnect(QueuePid, DoCleanup)
+                                         vmq_queue:force_disconnect(QueuePid, ?ADMINISTRATIVE_ACTION, DoCleanup)
                                  end, ok, QueryString1),
                                [clique_status:text("Done")]
                        end;

--- a/apps/vmq_server/src/vmq_mqtt_fsm.erl
+++ b/apps/vmq_server/src/vmq_mqtt_fsm.erl
@@ -407,7 +407,7 @@ connected(retry,
            retry_queue=RetryQueue} = State) ->
     {RetryFrames, NewRetryQueue} = handle_retry(RetryInterval, RetryQueue, WAcks),
     {State#state{retry_queue=NewRetryQueue}, RetryFrames};
-connected(disconnect, State) ->
+connected({disconnect, _Reason}, State) ->
     lager:debug("stop due to disconnect", []),
     terminate(normal, State);
 connected(check_keepalive, #state{last_time_active=Last, keep_alive=KeepAlive,

--- a/apps/vmq_server/src/vmq_ranch.erl
+++ b/apps/vmq_server/src/vmq_ranch.erl
@@ -201,7 +201,7 @@ handle_message({Proto, _, Data}, #st{proto_tag={Proto, _, _}, fsm_mod=FsmMod} = 
     end;
 handle_message({ProtoClosed, _}, #st{proto_tag={_, ProtoClosed, _}, fsm_mod=FsmMod} = State) ->
     %% we regard a tcp_closed as 'normal'
-    _ = FsmMod:msg_in(disconnect, State#st.fsm_state),
+    _ = FsmMod:msg_in({disconnect, ?NORMAL_DISCONNECT}, State#st.fsm_state),
     {exit, normal, State};
 handle_message({ProtoErr, _, Error}, #st{proto_tag={_, _, ProtoErr}} = State) ->
     _ = vmq_metrics:incr_socket_error(),
@@ -225,7 +225,8 @@ handle_message(restart_work, #st{throttled=true} = State) ->
     #st{proto_tag={Proto, _, _}, socket=Socket} = State,
     handle_message({Proto, Socket, <<>>}, State#st{throttled=false});
 handle_message({'EXIT', _Parent, Reason}, #st{fsm_state=FsmState0, fsm_mod=FsmMod} = State) ->
-    _ = FsmMod:msg_in(disconnect, FsmState0),
+    %% TODO: this should probably not be a normal disconnect...
+    _ = FsmMod:msg_in({disconnect, ?NORMAL_DISCONNECT}, FsmState0),
     {exit, Reason, State};
 handle_message({system, From, Request}, #st{parent=Parent}= State) ->
     sys:handle_system_msg(Request, From, Parent, ?MODULE, [], State);

--- a/apps/vmq_server/src/vmq_reg.erl
+++ b/apps/vmq_server/src/vmq_reg.erl
@@ -139,7 +139,7 @@ register_subscriber(SessionPid, SubscriberId,
     case vmq_queue_sup_sup:start_queue(SubscriberId) of
         {ok, true, OldQPid} when CleanSession ->
             %% cleanup queue
-            vmq_queue:cleanup(OldQPid),
+            vmq_queue:cleanup(OldQPid, ?SESSION_TAKEN_OVER),
             vmq_queue_sup_sup:start_queue(SubscriberId);
         Ret -> Ret
     end,

--- a/apps/vmq_server/src/vmq_server.hrl
+++ b/apps/vmq_server/src/vmq_server.hrl
@@ -21,10 +21,12 @@
 -define(ADMINISTRATIVE_ACTION,    administrative_action).
 -define(DISCONNECT_KEEP_ALIVE,    disconnect_keep_alive).
 -define(DISCONNECT_MIGRATION,     disconnect_migration).
+-define(CLIENT_DISCONNECT,        mqtt_client_disconnect).
 
 -type disconnect_reasons() ::
         ?NORMAL_DISCONNECT |
         ?SESSION_TAKEN_OVER |
         ?ADMINISTRATIVE_ACTION |
         ?DISCONNECT_KEEP_ALIVE |
-        ?DISCONNECT_MIGRATION.
+        ?DISCONNECT_MIGRATION |
+        ?CLIENT_DISCONNECT.

--- a/apps/vmq_server/src/vmq_server.hrl
+++ b/apps/vmq_server/src/vmq_server.hrl
@@ -14,3 +14,17 @@
           sg_policy=prefer_local:: sg_policy()
          }).
 -type msg()             :: #vmq_msg{}.
+
+%% TODO: these definitions should probably be moved somewhere else.
+-define(SESSION_TAKEN_OVER,       session_taken_over).
+-define(NORMAL_DISCONNECT,        normal_disconnect).
+-define(ADMINISTRATIVE_ACTION,    administrative_action).
+-define(DISCONNECT_KEEP_ALIVE,    disconnect_keep_alive).
+-define(DISCONNECT_MIGRATION,     disconnect_migration).
+
+-type disconnect_reasons() ::
+        ?NORMAL_DISCONNECT |
+        ?SESSION_TAKEN_OVER |
+        ?ADMINISTRATIVE_ACTION |
+        ?DISCONNECT_KEEP_ALIVE |
+        ?DISCONNECT_MIGRATION.

--- a/apps/vmq_server/src/vmq_websocket.erl
+++ b/apps/vmq_server/src/vmq_websocket.erl
@@ -13,6 +13,8 @@
 %% limitations under the License.
 
 -module(vmq_websocket).
+-include("vmq_server.hrl").
+
 -export([init/3]).
 -export([websocket_init/3]).
 -export([websocket_handle/3]).
@@ -108,7 +110,7 @@ websocket_terminate(_Reason, _Req, #st{fsm_state=terminated}) ->
     _ = vmq_metrics:incr_socket_close(),
     ok;
 websocket_terminate(_Reason, _Req, #st{fsm_mod=FsmMod, fsm_state=FsmState}) ->
-    _ = FsmMod:msg_in(disconnect, FsmState),
+    _ = FsmMod:msg_in({disconnect, ?NORMAL_DISCONNECT}, FsmState),
     _ = vmq_metrics:incr_socket_close(),
     ok.
 

--- a/apps/vmq_server/test/vmq_queue_SUITE.erl
+++ b/apps/vmq_server/test/vmq_queue_SUITE.erl
@@ -252,7 +252,7 @@ queue_force_disconnect_test(_) ->
     timer:sleep(50), % give some time to plumtree
 
     monitor(process, SessionPid1),
-    vmq_queue:force_disconnect(QPid0),
+    vmq_queue:force_disconnect(QPid0, ?ADMINISTRATIVE_ACTION),
 
     % ensure we got disconnected
     receive
@@ -281,7 +281,7 @@ queue_force_disconnect_cleanup_test(_) ->
     {ok, FoundMsgs} = vmq_lvldb_store:msg_store_find(SubscriberId),
     NumPubbedMsgs = length(FoundMsgs),
 
-    vmq_queue:force_disconnect(QPid0, true),
+    vmq_queue:force_disconnect(QPid0, ?ADMINISTRATIVE_ACTION, true),
 
     % Ensure all Subscriptions are gone
     [] = vmq_reg:subscriptions_for_subscriber_id(SubscriberId),

--- a/changelog.md
+++ b/changelog.md
@@ -15,6 +15,10 @@
   - Add support for subscriber data with subscription options.
 - Fix issue when validating a shared subscription topic (#756).
 - Fix issue with retried PUBREC frames (#750).
+- Make it possible to suppress the Last Will and Testament message if an
+  existing session already exists for the connecting client. This is
+  configurable via the hidden setting `suppress_lwt_on_session_takeover` in the
+  VerneMQ configuration file. The default is `off`.
 
 ## VerneMQ 1.4.0
 


### PR DESCRIPTION
This PR implements a new setting which can suppress LWT messages in case of a session takeover by setting the `suppress_lwt_on_session_takeover=on`. The new setting is hidden (not visible by default in the vernemq.conf file).

To implement this d075ff3 - 'Add reasons to queue cleanup and session disconnects' was backported/cherry picked from the mqtt5-preview branch as reason codes had already been generalized there.

This PR also introduces the `def_opts` map member to the `vmq_mqtt_fsm` state record, which is meant to hold non-fast-path settings. The idea is that if we store all settings directly in the record we'll have a memory overhead for all sessions, but if instead only non-default values are stored in the map, we don't have any overhead for default values. We can move other settings into this map later if needed.

This PR also refactors and simplifies a bit the `vmq_mqtt_fsm:terminate/2` and `vmq_mqtt_fsm:maybe_publish_last_will/1` functions, as well as introducing a function `vmq_mqtt_fsm:terminate_reason/1` which maps reasons to `normal` to make the ranch process shut down properly for normal shutdown reasons.

TODO: see how this merges with the MQTT5 branch.


