### PR TITLE
Remove cuttlefish warning about message_size_limit

### DIFF
--- a/apps/vmq_server/priv/vmq_server.schema
+++ b/apps/vmq_server/priv/vmq_server.schema
@@ -250,9 +250,14 @@
                                                                  ]}.
 {translation, "vmq_server.message_size_limit",
  fun(Conf) ->
-         S = cuttlefish:conf_get("message_size_limit", Conf),
-         cuttlefish:warn("message_size_limit is deprecated and has no effect, use max_message_size instead"),
-         S
+         Size = cuttlefish:conf_get("message_size_limit", Conf),
+         case Size of
+            0 ->
+                Size;
+            _ ->
+                cuttlefish:warn("message_size_limit is deprecated and has no effect, use max_message_size instead"),
+                Size
+         end
  end}.
 
 %% @doc If a message is published with a QoS lower than the QoS of the subscription it is

--- a/changelog.md
+++ b/changelog.md
@@ -21,6 +21,7 @@
   VerneMQ configuration file. The default is `off`.
 - Fix issue with PUBREL frames retried after client reconnects (#762).
 - Refactor and cleanup retry mechanism.
+- Warn about deprecated setting `message_size_limit` only when it has been defined.
 
 ## VerneMQ 1.4.0
 


### PR DESCRIPTION
The setting `message_size_limit` has been deprecated for long but
still when one runs `vernemq config generate` or starts the broker
without a configuration file, it warns about this setting even when is
not set. This change makes it warn only if the setting has been
changed to a non-default value.

Replaces #748 