### PR TITLE
Support lwt suppression in the mqtt5 fsm

### DIFF
--- a/apps/vmq_commons/src/vmq_topic.erl
+++ b/apps/vmq_commons/src/vmq_topic.erl
@@ -112,14 +112,14 @@ validate_publish_topic(Topic, L, Acc) ->
     end.
 
 validate_subscribe_topic(<<"+/", Rest/binary>>, _, Acc) -> validate_subscribe_topic(Rest, 0, [<<"+">>|Acc]);
-validate_subscribe_topic(<<"+">>, _, Acc) -> {ok, reverse([<<"+">>|Acc])};
-validate_subscribe_topic(<<"#">>, _, Acc) -> {ok, reverse([<<"#">>|Acc])};
+validate_subscribe_topic(<<"+">>, _, Acc) -> validate_shared_subscription(reverse([<<"+">>|Acc]));
+validate_subscribe_topic(<<"#">>, _, Acc) -> validate_shared_subscription(reverse([<<"#">>|Acc]));
 validate_subscribe_topic(Topic, L, Acc) ->
     case Topic of
         <<Word:L/binary, "/", Rest/binary>> ->
             validate_subscribe_topic(Rest, 0, [Word|Acc]);
         <<Word:L/binary>> ->
-            {ok, lists:reverse([Word|Acc])};
+            validate_shared_subscription(reverse([Word|Acc]));
         <<_:L/binary, "+", _/binary>> ->
             {error, 'no_+_allowed_in_word'};
         <<_:L/binary, "#", _/binary>> ->
@@ -127,6 +127,10 @@ validate_subscribe_topic(Topic, L, Acc) ->
         _ ->
             validate_subscribe_topic(Topic, L + 1, Acc)
     end.
+
+validate_shared_subscription([<<"$share">>, _Group, _FirstWord | _] = Topic) -> {ok, Topic};
+validate_shared_subscription([<<"$share">> | _] = _Topic) -> {error, invalid_shared_subscription};
+validate_shared_subscription(Topic) -> {ok, Topic}.
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
@@ -195,6 +199,10 @@ validate_wildcard_test() ->
     {error, 'no_#_allowed_in_word'} = validate_topic(subscribe, <<"/test/testtopic#">>),
     {error, 'no_+_allowed_in_word'} = validate_topic(subscribe, <<"/test/+testtopic">>),
     {error, 'no_+_allowed_in_word'} = validate_topic(subscribe, <<"/testtesttopic+">>).
+
+validate_shared_subscription_test() ->
+    {error, invalid_shared_subscription} = validate_topic(subscribe, <<"$share/mygroup">>),
+    {ok, [<<"$share">>, <<"mygroup">>, <<"a">>, <<"b">>]} = validate_topic(subscribe, <<"$share/mygroup/a/b">>).
 
 validate_unword_test() ->
     rand:seed(exsplus, erlang:timestamp()),

--- a/apps/vmq_server/priv/vmq_server.schema
+++ b/apps/vmq_server/priv/vmq_server.schema
@@ -1454,6 +1454,15 @@
                                                    hidden
                                                   ]}.
 
+%% @doc Suppress the Last Will and Testament message if an existing
+%% session already exists for the connecting client.
+{mapping, "suppress_lwt_on_session_takeover",
+ "vmq_server.suppress_lwt_on_session_takeover", [
+                                                 {default, off},
+                                                 {datatype, flag},
+                                                 hidden
+                                                ]}.
+
 %% @doc plugins.<plugin> enables/disables a plugin.
 %%
 %% Plugin specific settings are set via the plugin itself, i.e., to

--- a/apps/vmq_server/src/vmq_cluster_com.erl
+++ b/apps/vmq_server/src/vmq_cluster_com.erl
@@ -230,8 +230,9 @@ to_vmq_msg({vmq_msg, MsgRef, RoutingKey, Payload,
       };
 to_vmq_msg(InMsg) when is_tuple(InMsg),
                        size(InMsg) > size(#vmq_msg{}) ->
-    %% Msg has more fields than the current vmq_msg record. Strip away
-    %% the ones we don't know.
+    %% we have a msg with unknown elements. As we don't know
+    %% how to handle those we strip them away and fill the
+    %% rest into the `vmq_msg` record we know.
     #vmq_msg{
        msg_ref = element(2, InMsg),
        routing_key = element(3, InMsg),

--- a/apps/vmq_server/src/vmq_config_cli.erl
+++ b/apps/vmq_server/src/vmq_config_cli.erl
@@ -55,7 +55,8 @@ register_config_() ->
      "topic_alias_max_broker",
      "max_last_will_delay",
      "receive_max_client",
-     "receive_max_broker"
+     "receive_max_broker",
+     "suppress_lwt_on_session_takeover"
     ],
     _ = [clique:register_config([Key], fun register_config_callback/3)
          || Key <- ConfigKeys],

--- a/apps/vmq_server/src/vmq_queue.erl
+++ b/apps/vmq_server/src/vmq_queue.erl
@@ -890,7 +890,7 @@ cleanup_queue(SId, Queue) ->
 cleanup_queue_(SId, {{value, {deliver, _, _} = Msg}, NewQueue}) ->
     maybe_offline_delete(SId, Msg),
     cleanup_queue_(SId, queue:out(NewQueue));
-cleanup_queue_(SId, {{value, {deliver_bin, _}}, NewQueue}) ->
+cleanup_queue_(SId, {{value, {deliver_pubrel, _}}, NewQueue}) ->
     % no need to deref
     cleanup_queue_(SId, queue:out(NewQueue));
 cleanup_queue_(SId, {{value, MsgRef}, NewQueue}) when is_binary(MsgRef) ->

--- a/apps/vmq_server/src/vmq_reg.erl
+++ b/apps/vmq_server/src/vmq_reg.erl
@@ -402,7 +402,7 @@ deliver_retained({MP, _} = SubscriberId, Topic, QoS, _SubOpts, _) ->
                            properties = Properties,
                            expiry_ts = ExpiryTs}}, _) ->
               Msg = #vmq_msg{routing_key=T,
-                             payload=Payload,
+                             payload=retain_pre(Payload),
                              retain=true,
                              qos=QoS,
                              dup=false,

--- a/apps/vmq_server/src/vmq_server.hrl
+++ b/apps/vmq_server/src/vmq_server.hrl
@@ -32,6 +32,7 @@
 %% *real* MQTT reason codes.
 -define(DISCONNECT_KEEP_ALIVE,    disconnect_keep_alive).
 -define(DISCONNECT_MIGRATION,     disconnect_migration).
+-define(CLIENT_DISCONNECT,        mqtt_client_disconnect).
 
 -type disconnect_reasons() ::
         ?NOT_AUTHORIZED |
@@ -42,4 +43,5 @@
         ?DISCONNECT_MIGRATION |
         ?BAD_AUTHENTICATION_METHOD |
         ?PROTOCOL_ERROR |
-        ?RECEIVE_MAX_EXCEEDED.
+        ?RECEIVE_MAX_EXCEEDED |
+        ?CLIENT_DISCONNECT.

--- a/apps/vmq_server/test/vmq_cluster_SUITE.erl
+++ b/apps/vmq_server/test/vmq_cluster_SUITE.erl
@@ -750,8 +750,6 @@ cross_node_publish_subscribe(Config) ->
                  ++ Payloads),
     receive_nothing(200).
 
-
-
 convert_new_msgs_to_old_format(_Config) ->
     %% create a #vmq_msg{} as a raw tuple.
     Orig = {

--- a/apps/vmq_server/test/vmq_subscribe_SUITE.erl
+++ b/apps/vmq_server/test/vmq_subscribe_SUITE.erl
@@ -359,9 +359,9 @@ subpub_qos2_test(_) ->
     ok = packet:expect_packet(Socket, "suback", Suback),
     ok = gen_tcp:send(Socket, Publish1),
     ok = packet:expect_packet(Socket, "pubrec", Pubrec1),
+    ok = packet:expect_packet(Socket, "publish2", Publish2),
     ok = gen_tcp:send(Socket, Pubrel1),
     ok = packet:expect_packet(Socket, "pubcomp", Pubcomp1),
-    ok = packet:expect_packet(Socket, "publish2", Publish2),
     ok = gen_tcp:send(Socket, Pubrec2),
     ok = packet:expect_packet(Socket, "pubrel2", Pubrel2),
     ok = gen_tcp:close(Socket).

--- a/changelog.md
+++ b/changelog.md
@@ -28,6 +28,14 @@ handle topic aliases from the client as per the MQTTv5 spec.
     as messages.
   - Refactor the retained message store to support versions.
   - Add support for subscriber data with subscription options.
+- Fix issue when validating a shared subscription topic (#756).
+- Fix issue with retried PUBREC frames (#750).
+- Make it possible to suppress the Last Will and Testament message if an
+  existing session already exists for the connecting client. This is
+  configurable via the hidden setting `suppress_lwt_on_session_takeover` in the
+  VerneMQ configuration file. The default is `off`.
+- Fix issue with PUBREL frames retried after client reconnects (#762).
+- Refactor and cleanup retry mechanism.
 
 ## VerneMQ 1.4.0
 


### PR DESCRIPTION
Port the suppress lwt feature to the mqtt5 fsm.

This builds on top of #773 which should be handled before merging this one.