### PR TITLE
Rename mqtt5 hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ doesn't look right! We'd love to get your feedback!
 
 On this branch MQTTv5 is enabled by default and all MQTTv5 actions are allowed
 as a plugin called `vmq_allow_all_v5` is enabled which implements the
-`auth_on_register_v1`, `auth_on_subscribe_v1` and `auth_on_publish_v1`, all of
+`auth_on_register_m5`, `auth_on_subscribe_m5` and `auth_on_publish_m5`, all of
 them simply return `ok` allowing the actions.
 
 So to get started, simply create a clone of this repository and switch to this
@@ -102,6 +102,6 @@ issue title with `MQTTv5:`. You're also more than welcome to reach out to us on
 
 MQTTv5 plugins use a different set of hooks as MQTTv5 has more features than
 MQTTv4. The hooks in MQTTv5 has the same names as in MQTTv4, but are post-fixed
-with `_v1` (hook version 1), so for example in MQTTv5 `auth_on_register_v1`
-corresponds to the MQTTv4 hook `auth_on_register`. MQTTv5 also introduces a new
-`on_auth_v1` hook to support enhanced (re-)authentication.
+with `_m5`, so for example in MQTTv5 `auth_on_register_m5` corresponds to the
+MQTTv4 hook `auth_on_register`. MQTTv5 also introduces a new `on_auth_m5` hook
+to support enhanced (re-)authentication.

--- a/apps/vmq_allow_all_v5/README.md
+++ b/apps/vmq_allow_all_v5/README.md
@@ -1,7 +1,7 @@
 # MQTTv5 dummy plugin
 
-This plugin implements the `auth_on_register_v1`, `auth_on_publish_v1` and
-`auth_on_subscribe_v1` hooks and allowed all operations.
+This plugin implements the `auth_on_register_m5`, `auth_on_publish_m5` and
+`auth_on_subscribe_m5` hooks and allowed all operations.
 
 This plugin will be removed when or after merging the MQTTv5 functionality to
 the master branch.

--- a/apps/vmq_allow_all_v5/src/vmq_allow_all_v5.app.src
+++ b/apps/vmq_allow_all_v5/src/vmq_allow_all_v5.app.src
@@ -9,9 +9,9 @@
   {env,[
        {vmq_plugin_hooks,
         [
-         {vmq_allow_all_v5, auth_on_register_v1, 6, []},
-         {vmq_allow_all_v5, auth_on_publish_v1, 7, []},
-         {vmq_allow_all_v5, auth_on_subscribe_v1, 4, []}
+         {vmq_allow_all_v5, auth_on_register_m5, 6, []},
+         {vmq_allow_all_v5, auth_on_publish_m5, 7, []},
+         {vmq_allow_all_v5, auth_on_subscribe_m5, 4, []}
         ]
        }]},
   {modules, []},

--- a/apps/vmq_allow_all_v5/src/vmq_allow_all_v5.erl
+++ b/apps/vmq_allow_all_v5/src/vmq_allow_all_v5.erl
@@ -1,26 +1,26 @@
 -module(vmq_allow_all_v5).
 
--behaviour(auth_on_register_v1_hook).
--behaviour(auth_on_publish_v1_hook).
--behaviour(auth_on_subscribe_v1_hook).
+-behaviour(auth_on_register_m5_hook).
+-behaviour(auth_on_publish_m5_hook).
+-behaviour(auth_on_subscribe_m5_hook).
 
 %% API exports
 -export([
-         auth_on_register_v1/6,
-         auth_on_publish_v1/7,
-         auth_on_subscribe_v1/4]).
+         auth_on_register_m5/6,
+         auth_on_publish_m5/7,
+         auth_on_subscribe_m5/4]).
 
 %%====================================================================
 %% API functions
 %%====================================================================
 
-auth_on_register_v1(_,_,_,_,_,_) ->
+auth_on_register_m5(_,_,_,_,_,_) ->
     ok.
 
-auth_on_publish_v1(_,_,_,_,_,_,_) ->
+auth_on_publish_m5(_,_,_,_,_,_,_) ->
     ok.
 
-auth_on_subscribe_v1(_,_,_,_) ->
+auth_on_subscribe_m5(_,_,_,_) ->
     ok.
 
 %%====================================================================

--- a/apps/vmq_mqtt5_demo_plugin/src/vmq_mqtt5_demo_plugin.app.src
+++ b/apps/vmq_mqtt5_demo_plugin/src/vmq_mqtt5_demo_plugin.app.src
@@ -11,15 +11,15 @@
   {env,[
        {vmq_plugin_hooks,
         [
-         {vmq_mqtt5_demo_plugin, auth_on_register_v1, 6, []},
-         {vmq_mqtt5_demo_plugin, on_register_v1, 4, []},
-         {vmq_mqtt5_demo_plugin, auth_on_publish_v1, 7, []},
-         {vmq_mqtt5_demo_plugin, on_publish_v1, 7, []},
-         {vmq_mqtt5_demo_plugin, auth_on_subscribe_v1, 4, []},
-         {vmq_mqtt5_demo_plugin, on_subscribe_v1, 3, []},
-         {vmq_mqtt5_demo_plugin, on_unsubscribe_v1, 4, []},
-         {vmq_mqtt5_demo_plugin, on_auth_v1, 1, []},
-         {vmq_mqtt5_demo_plugin, on_deliver_v1, 5, []}
+         {vmq_mqtt5_demo_plugin, auth_on_register_m5, 6, []},
+         {vmq_mqtt5_demo_plugin, on_register_m5, 4, []},
+         {vmq_mqtt5_demo_plugin, auth_on_publish_m5, 7, []},
+         {vmq_mqtt5_demo_plugin, on_publish_m5, 7, []},
+         {vmq_mqtt5_demo_plugin, auth_on_subscribe_m5, 4, []},
+         {vmq_mqtt5_demo_plugin, on_subscribe_m5, 3, []},
+         {vmq_mqtt5_demo_plugin, on_unsubscribe_m5, 4, []},
+         {vmq_mqtt5_demo_plugin, on_auth_m5, 1, []},
+         {vmq_mqtt5_demo_plugin, on_deliver_m5, 5, []}
         ]
        }]},
   {modules, []},

--- a/apps/vmq_mqtt5_demo_plugin/src/vmq_mqtt5_demo_plugin.erl
+++ b/apps/vmq_mqtt5_demo_plugin/src/vmq_mqtt5_demo_plugin.erl
@@ -2,27 +2,27 @@
 
 -include_lib("vernemq_dev/include/vernemq_dev.hrl").
 
--behaviour(auth_on_register_v1_hook).
--behaviour(on_register_v1_hook).
--behaviour(auth_on_publish_v1_hook).
--behaviour(on_publish_v1_hook).
--behaviour(auth_on_subscribe_v1_hook).
--behaviour(on_subscribe_v1_hook).
--behaviour(on_unsubscribe_v1_hook).
--behaviour(on_auth_v1_hook).
--behaviour(on_deliver_v1_hook).
+-behaviour(auth_on_register_m5_hook).
+-behaviour(on_register_m5_hook).
+-behaviour(auth_on_publish_m5_hook).
+-behaviour(on_publish_m5_hook).
+-behaviour(auth_on_subscribe_m5_hook).
+-behaviour(on_subscribe_m5_hook).
+-behaviour(on_unsubscribe_m5_hook).
+-behaviour(on_auth_m5_hook).
+-behaviour(on_deliver_m5_hook).
 
 %% API exports
 -export([
-         auth_on_register_v1/6,
-         on_register_v1/4,
-         auth_on_publish_v1/7,
-         on_publish_v1/7,
-         auth_on_subscribe_v1/4,
-         on_subscribe_v1/3,
-         on_unsubscribe_v1/4,
-         on_auth_v1/1,
-         on_deliver_v1/5]).
+         auth_on_register_m5/6,
+         on_register_m5/4,
+         auth_on_publish_m5/7,
+         on_publish_m5/7,
+         auth_on_subscribe_m5/4,
+         on_subscribe_m5/3,
+         on_unsubscribe_m5/4,
+         on_auth_m5/1,
+         on_deliver_m5/5]).
 
 %%====================================================================
 %% API functions
@@ -38,94 +38,94 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%
 %%%%% Register hooks %%%%%
 %%%%%%%%%%%%%%%%%%%%%%%%%%
-auth_on_register_v1(Peer,SubscriberId,Username,Password,CleanStart,Properties) ->
-    ?LOG([auth_on_register_v1,Peer,SubscriberId,Username,Password,CleanStart,Properties]),
-    auth_on_register_v1_(Peer,SubscriberId,Username,Password,CleanStart,Properties).
+auth_on_register_m5(Peer,SubscriberId,Username,Password,CleanStart,Properties) ->
+    ?LOG([auth_on_register_m5,Peer,SubscriberId,Username,Password,CleanStart,Properties]),
+    auth_on_register_m5_(Peer,SubscriberId,Username,Password,CleanStart,Properties).
 
-auth_on_register_v1_(_Peer,_SubscriberId,<<"quota_exceeded">>,_Password,_CleanStart,_Properties) ->
+auth_on_register_m5_(_Peer,_SubscriberId,<<"quota_exceeded">>,_Password,_CleanStart,_Properties) ->
     {error, #{reason_code => ?QUOTA_EXCEEDED,
               properties => #{?P_REASON_STRING => <<"You have exceeded your quota">>}}};
-auth_on_register_v1_(_Peer,_SubscriberId,_Username,_Password,_CleanStart,_Properties) ->
+auth_on_register_m5_(_Peer,_SubscriberId,_Username,_Password,_CleanStart,_Properties) ->
     ok.
 
-on_register_v1(Peer,SubscriberId,Username,Properties) ->
-    ?LOG([on_register_v1,Peer,SubscriberId,Username,Properties]),
+on_register_m5(Peer,SubscriberId,Username,Properties) ->
+    ?LOG([on_register_m5,Peer,SubscriberId,Username,Properties]),
     ok.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%
 %%%%% Publish hooks %%%%%
 %%%%%%%%%%%%%%%%%%%%%%%%%
-auth_on_publish_v1(Username,SubscriberId,QoS,Topic,Payload,IsRetain,Properties) ->
-    ?LOG([auth_on_publish_v1,Username,SubscriberId,QoS,Topic,Payload,IsRetain,Properties]),
-    auth_on_publish_v1_(Username,SubscriberId,QoS,Topic,Payload,IsRetain,Properties).
+auth_on_publish_m5(Username,SubscriberId,QoS,Topic,Payload,IsRetain,Properties) ->
+    ?LOG([auth_on_publish_m5,Username,SubscriberId,QoS,Topic,Payload,IsRetain,Properties]),
+    auth_on_publish_m5_(Username,SubscriberId,QoS,Topic,Payload,IsRetain,Properties).
 
-auth_on_publish_v1_(_Username,_SubscriberId,_QoS,[<<"invalid">>, <<"topic">>],_Payload,_IsRetain,_Properties) ->
+auth_on_publish_m5_(_Username,_SubscriberId,_QoS,[<<"invalid">>, <<"topic">>],_Payload,_IsRetain,_Properties) ->
     {error, #{reason_code => ?TOPIC_NAME_INVALID,
               properties => #{?P_REASON_STRING => <<"Invalid topic name">>}}};
-auth_on_publish_v1_(_Username,_SubscriberId,_QoS,_Topic,_Payload,_IsRetain,_Properties) ->
+auth_on_publish_m5_(_Username,_SubscriberId,_QoS,_Topic,_Payload,_IsRetain,_Properties) ->
     ok.
 
-on_publish_v1(Username,SubscriberId,QoS,Topic,Payload,IsRetain,Properties)->
-    ?LOG([on_publish_v1,Username,SubscriberId,QoS,Topic,Payload,IsRetain,Properties]),
+on_publish_m5(Username,SubscriberId,QoS,Topic,Payload,IsRetain,Properties)->
+    ?LOG([on_publish_m5,Username,SubscriberId,QoS,Topic,Payload,IsRetain,Properties]),
     ok.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%%%% Subscribe hooks %%%%%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%
-auth_on_subscribe_v1(Username,SubscriberId,Topics,Properties) ->
-    ?LOG([auth_on_subscribe_v1,Username,SubscriberId,Topics,Properties]),
-    auth_on_subscribe_v1_(Username,SubscriberId,Topics,Properties).
+auth_on_subscribe_m5(Username,SubscriberId,Topics,Properties) ->
+    ?LOG([auth_on_subscribe_m5,Username,SubscriberId,Topics,Properties]),
+    auth_on_subscribe_m5_(Username,SubscriberId,Topics,Properties).
 
-auth_on_subscribe_v1_(_Username,_SubscriberId,
+auth_on_subscribe_m5_(_Username,_SubscriberId,
                       [{[<<"suback">>,<<"withprops">>], _}] = Topics,
                       _Properties) ->
     {ok, #{topics => Topics,
            properties => #{?P_USER_PROPERTY => [{<<"key">>, <<"val">>}],
                            ?P_REASON_STRING => <<"successful subscribe">>}}};
-auth_on_subscribe_v1_(_Username,_SubscriberId,_Topics,_Properties) ->
+auth_on_subscribe_m5_(_Username,_SubscriberId,_Topics,_Properties) ->
     ok.
 
-on_subscribe_v1(Username,SubscriberId,Topics)->
-    ?LOG([on_subscribe_v1,Username,SubscriberId,Topics]),
+on_subscribe_m5(Username,SubscriberId,Topics)->
+    ?LOG([on_subscribe_m5,Username,SubscriberId,Topics]),
     ok.
 
-on_unsubscribe_v1(Username,SubscriberId,Topics,Properties) ->
-    ?LOG([on_unsubscribe_v1,Username,SubscriberId,Topics,Properties]),
-    on_unsubscribe_v1_(Username,SubscriberId,Topics,Properties).
+on_unsubscribe_m5(Username,SubscriberId,Topics,Properties) ->
+    ?LOG([on_unsubscribe_m5,Username,SubscriberId,Topics,Properties]),
+    on_unsubscribe_m5_(Username,SubscriberId,Topics,Properties).
 
-on_unsubscribe_v1_(_Username,_SubscriberId,
+on_unsubscribe_m5_(_Username,_SubscriberId,
                    [[<<"unsuback">>,<<"withprops">>]] = Topics,
                    _Properties) ->
     {ok, #{topics => Topics,
            properties => #{?P_USER_PROPERTY => [{<<"key">>, <<"val">>}],
                            ?P_REASON_STRING => <<"Unsubscribe worked">>}}};
-on_unsubscribe_v1_(_Username,_SubscriberId,_Topics,_Properties) ->
+on_unsubscribe_m5_(_Username,_SubscriberId,_Topics,_Properties) ->
     ok.
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%%%% Enh. Auth hooks %%%%%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%
-on_auth_v1(Properties) ->
-    ?LOG([on_auth_v1, Properties]),
-    on_auth_v1_(Properties).
+on_auth_m5(Properties) ->
+    ?LOG([on_auth_m5, Properties]),
+    on_auth_m5_(Properties).
 
-on_auth_v1_(#{?P_AUTHENTICATION_METHOD := <<"method1">>,
+on_auth_m5_(#{?P_AUTHENTICATION_METHOD := <<"method1">>,
               ?P_AUTHENTICATION_DATA := <<"client1">>}) ->
     {ok, #{reason_code => ?CONTINUE_AUTHENTICATION,
            properties => #{?P_AUTHENTICATION_METHOD => <<"method1">>,
                            ?P_AUTHENTICATION_DATA => <<"server1">>}}};
-on_auth_v1_(#{?P_AUTHENTICATION_METHOD := <<"method1">>,
+on_auth_m5_(#{?P_AUTHENTICATION_METHOD := <<"method1">>,
               ?P_AUTHENTICATION_DATA := <<"client2">>}) ->
     {ok, #{reason_code => ?SUCCESS,
            properties => #{?P_AUTHENTICATION_METHOD => <<"method1">>,
                            ?P_AUTHENTICATION_DATA => <<"server2">>}}};
-on_auth_v1_(#{?P_AUTHENTICATION_METHOD := <<"method1">>,
+on_auth_m5_(#{?P_AUTHENTICATION_METHOD := <<"method1">>,
               ?P_AUTHENTICATION_DATA := <<"baddata">>}) ->
     %% any other auth method we just reject.
     {error, #{reason_code => ?NOT_AUTHORIZED,
               properties => #{?P_REASON_STRING => <<"Bad authentication data: baddata">>}}};
-on_auth_v1_(_) ->
+on_auth_m5_(_) ->
     {error, unexpected_authentication_attempt}.
 
 
@@ -133,6 +133,6 @@ on_auth_v1_(_) ->
 %%%%%%%%%%%%%%%%%%%%%%%%%%
 %%%%% Delivery hooks %%%%%
 %%%%%%%%%%%%%%%%%%%%%%%%%%
-on_deliver_v1(Username,SubscriberId,Topic,Properties,Payload) ->
-    ?LOG([on_deliver_v1,Username,SubscriberId,Topic,Properties,Payload]),
+on_deliver_m5(Username,SubscriberId,Topic,Properties,Payload) ->
+    ?LOG([on_deliver_m5,Username,SubscriberId,Topic,Properties,Payload]),
     ok.

--- a/apps/vmq_plugin/test/vmq_plugin_SUITE.erl
+++ b/apps/vmq_plugin/test/vmq_plugin_SUITE.erl
@@ -109,13 +109,13 @@ plugin_with_compat_hooks(_Config) ->
         [{sample_hook_name_v0, test_compat_mod, sample_hook_v0, 2}],
     application:set_env(vmq_plugin, vmq_plugin_hooks, Hooks),
     ok = vmq_plugin_mgr:enable_plugin(vmq_plugin, [{path, code:lib_dir(vmq_plugin)},
-                                                   {compat, {sample_hook_name_v1,
+                                                   {compat, {sample_hook_name_m5,
                                                              test_compat_mod,
                                                              sample_hook_v1_to_v0,
                                                              3}}]),
-    {ok, {1,2,3}} = vmq_plugin:all_till_ok(sample_hook_name_v1, [1,2,3]),
-    [{ok, {1,2,3}}] = vmq_plugin:all(sample_hook_name_v1, [1,2,3]),
-    {ok, {1,2,3}} = vmq_plugin:only(sample_hook_name_v1, [1,2,3]).
+    {ok, {1,2,3}} = vmq_plugin:all_till_ok(sample_hook_name_m5, [1,2,3]),
+    [{ok, {1,2,3}}] = vmq_plugin:all(sample_hook_name_m5, [1,2,3]),
+    {ok, {1,2,3}} = vmq_plugin:only(sample_hook_name_m5, [1,2,3]).
 
 module_plugin_with_compat_hooks(_Config) ->
     {ok, _} = application:ensure_all_started(vmq_plugin),
@@ -132,7 +132,7 @@ module_plugin_with_compat_hooks(_Config) ->
                                              test_compat_mod,
                                              sample_hook_v0,
                                              2,
-                                             [{compat, {sample_hook_name_v1,
+                                             [{compat, {sample_hook_name_m5,
                                                         test_compat_mod,
                                                         sample_hook_v1_to_v0,
                                                         3}}
@@ -144,15 +144,15 @@ module_plugin_with_compat_hooks(_Config) ->
     {ok, {1,2}} = vmq_plugin:only(sample_hook_name_v0, [1,2]),
 
     %% check that the compat hook works as well.
-    {ok, {1,2,3}} = vmq_plugin:all_till_ok(sample_hook_name_v1, [1,2,3]),
-    [{ok, {1,2,3}}] = vmq_plugin:all(sample_hook_name_v1, [1,2,3]),
-    {ok, {1,2,3}} = vmq_plugin:only(sample_hook_name_v1, [1,2,3]),
+    {ok, {1,2,3}} = vmq_plugin:all_till_ok(sample_hook_name_m5, [1,2,3]),
+    [{ok, {1,2,3}}] = vmq_plugin:all(sample_hook_name_m5, [1,2,3]),
+    {ok, {1,2,3}} = vmq_plugin:only(sample_hook_name_m5, [1,2,3]),
 
     ok = vmq_plugin_mgr:disable_module_plugin(sample_hook_name_v0,
                                               test_compat_mod,
                                               sample_hook_v0,
                                               2,
-                                              [{compat, {sample_hook_name_v1,
+                                              [{compat, {sample_hook_name_m5,
                                                          test_compat_mod,
                                                          sample_hook_v1_to_v0,
                                                          3}}
@@ -170,9 +170,9 @@ module_plugin_with_compat_hooks(_Config) ->
     {error, no_matching_hook_found} = vmq_plugin:only(sample_hook_name_v0, [1,2]),
 
     %% check that the compat hook is gone as well.
-    {error, no_matching_hook_found} = vmq_plugin:all_till_ok(sample_hook_name_v1, [1,2,3]),
-    {error, no_matching_hook_found} = vmq_plugin:all(sample_hook_name_v1, [1,2,3]),
-    {error, no_matching_hook_found} = vmq_plugin:only(sample_hook_name_v1, [1,2,3]).
+    {error, no_matching_hook_found} = vmq_plugin:all_till_ok(sample_hook_name_m5, [1,2,3]),
+    {error, no_matching_hook_found} = vmq_plugin:all(sample_hook_name_m5, [1,2,3]),
+    {error, no_matching_hook_found} = vmq_plugin:only(sample_hook_name_m5, [1,2,3]).
 
 
 

--- a/apps/vmq_server/src/vmq_plugin_compat_m5.erl
+++ b/apps/vmq_server/src/vmq_plugin_compat_m5.erl
@@ -13,10 +13,9 @@
 %% limitations under the License.
 
 %% @doc compatibility layer making it possible to reuse plugin hooks
-%% (v0 hooks) written for MQTTv3/4 in an MQTTv5 context. The
-%% compatibility layer maps MQTTv5 information to the MQTTv4
-%% equivalents and vice versa.
--module(vmq_plugin_compat_v1_v0).
+%% written for MQTTv3/4 in an MQTTv5 context. The compatibility layer
+%% maps MQTTv5 information to the MQTTv4 equivalents and vice versa.
+-module(vmq_plugin_compat_m5).
 
 -include_lib("vernemq_dev/include/vernemq_dev.hrl").
 
@@ -51,7 +50,7 @@ convert(on_publish, Mod, Fun,
         [User, SubscriberId, QoS, Topic, Payload, IsRetain, _Properties]) ->
     apply(Mod, Fun, [User, SubscriberId, QoS, Topic, Payload, IsRetain]);
 convert(auth_on_subscribe, Mod, Fun, [Username, SubscriberId, Topics, _Properties]) ->
-    case apply(Mod, Fun, [Username, SubscriberId, topics_v1_v0(Topics)]) of
+    case apply(Mod, Fun, [Username, SubscriberId, conv_m5_topics(Topics)]) of
         {ok, Topics} when is_list(Topics) ->
             {ok, #{topics => Topics}};
         Other -> Other
@@ -59,7 +58,7 @@ convert(auth_on_subscribe, Mod, Fun, [Username, SubscriberId, Topics, _Propertie
 convert(_, Mod, Fun, Args) ->
     apply(Mod, Fun, Args).
 
-topics_v1_v0(Topics) ->
+conv_m5_topics(Topics) ->
     lists:map(
       fun({T, {QoS, _SubOpts}}) ->
               {T, QoS}

--- a/apps/vmq_server/test/vmq_in_order_delivery_SUITE.erl
+++ b/apps/vmq_server/test/vmq_in_order_delivery_SUITE.erl
@@ -276,26 +276,26 @@ enable_on_subscribe() ->
            auth_on_subscribe, ?MODULE, hook_auth_on_subscribe, 3),
     ok = vmq_plugin_mgr:enable_module_plugin(
            auth_on_subscribe, ?MODULE, hook_auth_on_subscribe, 3,
-           [{compat, {auth_on_subscribe_v1, vmq_plugin_compat_v1_v0,
+           [{compat, {auth_on_subscribe_m5, vmq_plugin_compat_m5,
                      convert, 4}}]).
 enable_on_publish() ->
     ok = vmq_plugin_mgr:enable_module_plugin(
            auth_on_publish, ?MODULE, hook_auth_on_publish, 6),
     ok = vmq_plugin_mgr:enable_module_plugin(
            auth_on_publish, ?MODULE, hook_auth_on_publish, 6,
-           [{compat, {auth_on_publish_v1, vmq_plugin_compat_v1_v0,
+           [{compat, {auth_on_publish_m5, vmq_plugin_compat_m5,
                     convert, 7}}]).
 disable_on_subscribe() ->
     ok = vmq_plugin_mgr:disable_module_plugin(
            auth_on_subscribe, ?MODULE, hook_auth_on_subscribe, 3),
     ok = vmq_plugin_mgr:disable_module_plugin(
            auth_on_subscribe, ?MODULE, hook_auth_on_subscribe, 3,
-           [{compat, {auth_on_subscribe_v1, vmq_plugin_compat_v1_v0,
+           [{compat, {auth_on_subscribe_m5, vmq_plugin_compat_m5,
                       convert, 4}}]).
 disable_on_publish() ->
     ok = vmq_plugin_mgr:disable_module_plugin(
            auth_on_publish, ?MODULE, hook_auth_on_publish, 6),
     ok = vmq_plugin_mgr:disable_module_plugin(
            auth_on_publish, ?MODULE, hook_auth_on_publish, 6,
-           [{compat, {auth_on_publish_v1, vmq_plugin_compat_v1_v0,
+           [{compat, {auth_on_publish_m5, vmq_plugin_compat_m5,
                       convert, 7}}]).

--- a/apps/vmq_server/test/vmq_last_will_SUITE.erl
+++ b/apps/vmq_server/test/vmq_last_will_SUITE.erl
@@ -278,28 +278,28 @@ enable_on_subscribe() ->
       auth_on_subscribe, ?MODULE, hook_auth_on_subscribe, 3),
     ok = vmq_plugin_mgr:enable_module_plugin(
            auth_on_subscribe, ?MODULE, hook_auth_on_subscribe, 3,
-           [{compat, {auth_on_subscribe_v1, vmq_plugin_compat_v1_v0,
+           [{compat, {auth_on_subscribe_m5, vmq_plugin_compat_m5,
                       convert, 4}}]).
 enable_on_publish() ->
     ok = vmq_plugin_mgr:enable_module_plugin(
            auth_on_publish, ?MODULE, hook_auth_on_publish, 6),
     ok = vmq_plugin_mgr:enable_module_plugin(
            auth_on_publish, ?MODULE, hook_auth_on_publish, 6,
-           [{compat, {auth_on_publish_v1, vmq_plugin_compat_v1_v0,
+           [{compat, {auth_on_publish_m5, vmq_plugin_compat_m5,
                     convert, 7}}]).
 disable_on_subscribe() ->
     ok = vmq_plugin_mgr:disable_module_plugin(
            auth_on_subscribe, ?MODULE, hook_auth_on_subscribe, 3),
     ok = vmq_plugin_mgr:disable_module_plugin(
            auth_on_subscribe, ?MODULE, hook_auth_on_subscribe, 3,
-           [{compat, {auth_on_subscribe_v1, vmq_plugin_compat_v1_v0,
+           [{compat, {auth_on_subscribe_m5, vmq_plugin_compat_m5,
                       convert, 4}}]).
 disable_on_publish() ->
     ok = vmq_plugin_mgr:disable_module_plugin(
            auth_on_publish, ?MODULE, hook_auth_on_publish, 6),
     ok = vmq_plugin_mgr:disable_module_plugin(
            auth_on_publish, ?MODULE, hook_auth_on_publish, 6,
-           [{compat, {auth_on_publish_v1, vmq_plugin_compat_v1_v0,
+           [{compat, {auth_on_publish_m5, vmq_plugin_compat_m5,
                       convert, 7}}]).
 
 will_null_helper(Config) ->

--- a/apps/vmq_server/test/vmq_mqtt5_SUITE.erl
+++ b/apps/vmq_server/test/vmq_mqtt5_SUITE.erl
@@ -159,9 +159,9 @@ enhanced_authentication(_Config) ->
     %% Reason Code of 0x18 (Continue authentication) [MQTT-4.12.0-3].
 
     ok = vmq_plugin_mgr:enable_module_plugin(
-           auth_on_register_v1, ?MODULE, auth_on_register_ok_hook, 6),
+           auth_on_register_m5, ?MODULE, auth_on_register_ok_hook, 6),
     ok = vmq_plugin_mgr:enable_module_plugin(
-           on_auth_v1, ?MODULE, on_auth_hook, 1),
+           on_auth_m5, ?MODULE, on_auth_hook, 1),
 
     ClientId = "client-enhanced-auth",
     Connect = packetv5:gen_connect(ClientId, [{keepalive, 10},
@@ -179,9 +179,9 @@ enhanced_authentication(_Config) ->
     ok = gen_tcp:close(Socket),
 
     ok = vmq_plugin_mgr:disable_module_plugin(
-           on_auth_v1, ?MODULE, on_auth_hook, 1),
+           on_auth_m5, ?MODULE, on_auth_hook, 1),
     ok = vmq_plugin_mgr:disable_module_plugin(
-           auth_on_register_v1, ?MODULE, auth_on_register_ok_hook, 6).
+           auth_on_register_m5, ?MODULE, auth_on_register_ok_hook, 6).
 
 enhanced_auth_no_other_packets(_Config) ->
     %% If a Client sets an Authentication Method in the CONNECT, the
@@ -189,9 +189,9 @@ enhanced_auth_no_other_packets(_Config) ->
     %% packets until it has received a CONNACK packet [MQTT-3.1.2-30].
 
     ok = vmq_plugin_mgr:enable_module_plugin(
-           auth_on_register_v1, ?MODULE, auth_on_register_ok_hook, 6),
+           auth_on_register_m5, ?MODULE, auth_on_register_ok_hook, 6),
     ok = vmq_plugin_mgr:enable_module_plugin(
-           on_auth_v1, ?MODULE, on_auth_hook, 1),
+           on_auth_m5, ?MODULE, on_auth_hook, 1),
 
     ClientId = "client-enh-auth-wrong-packet",
     Connect = packetv5:gen_connect(ClientId, [{keepalive, 10},
@@ -205,9 +205,9 @@ enhanced_auth_no_other_packets(_Config) ->
     {error, closed} = gen_tcp:recv(Socket, 0, 1000),
 
     ok = vmq_plugin_mgr:disable_module_plugin(
-           on_auth_v1, ?MODULE, on_auth_hook, 1),
+           on_auth_m5, ?MODULE, on_auth_hook, 1),
     ok = vmq_plugin_mgr:disable_module_plugin(
-           auth_on_register_v1, ?MODULE, auth_on_register_ok_hook, 6).
+           auth_on_register_m5, ?MODULE, auth_on_register_ok_hook, 6).
 
 enhanced_auth_method_not_supported(_Config) ->
     %% If the Server does not support the Authentication Method
@@ -217,9 +217,9 @@ enhanced_auth_method_not_supported(_Config) ->
     %% Network Connection [MQTT-4.12.0-1].
 
     ok = vmq_plugin_mgr:enable_module_plugin(
-           auth_on_register_v1, ?MODULE, auth_on_register_ok_hook, 6),
+           auth_on_register_m5, ?MODULE, auth_on_register_ok_hook, 6),
     ok = vmq_plugin_mgr:enable_module_plugin(
-           on_auth_v1, ?MODULE, on_auth_bad_method_hook, 1),
+           on_auth_m5, ?MODULE, on_auth_bad_method_hook, 1),
 
     ClientId = "client-enh-auth-bad-auth",
     Connect = packetv5:gen_connect(ClientId, [{keepalive, 10},
@@ -229,9 +229,9 @@ enhanced_auth_method_not_supported(_Config) ->
     {error, closed} = gen_tcp:recv(Socket, 0,100),
 
     ok = vmq_plugin_mgr:disable_module_plugin(
-           on_auth_v1, ?MODULE, on_auth_bad_method_hook, 1),
+           on_auth_m5, ?MODULE, on_auth_bad_method_hook, 1),
     ok = vmq_plugin_mgr:disable_module_plugin(
-           auth_on_register_v1, ?MODULE, auth_on_register_ok_hook, 6).
+           auth_on_register_m5, ?MODULE, auth_on_register_ok_hook, 6).
 
 
 enhanced_auth_server_rejects(_Config) ->
@@ -248,9 +248,9 @@ enhanced_auth_new_auth_method_fails(_Config) ->
     %% same value as in the CONNECT packet [MQTT-4.12.0-5].
 
     ok = vmq_plugin_mgr:enable_module_plugin(
-           auth_on_register_v1, ?MODULE, auth_on_register_ok_hook, 6),
+           auth_on_register_m5, ?MODULE, auth_on_register_ok_hook, 6),
     ok = vmq_plugin_mgr:enable_module_plugin(
-           on_auth_v1, ?MODULE, on_auth_hook, 1),
+           on_auth_m5, ?MODULE, on_auth_hook, 1),
 
     ClientId = "client-enhanced-auth-wrong-method",
     Connect = packetv5:gen_connect(ClientId, [{keepalive, 10},
@@ -264,9 +264,9 @@ enhanced_auth_new_auth_method_fails(_Config) ->
     {error, closed} = gen_tcp:recv(Socket, 0, 100),
 
     ok = vmq_plugin_mgr:disable_module_plugin(
-           on_auth_v1, ?MODULE, on_auth_hook, 1),
+           on_auth_m5, ?MODULE, on_auth_hook, 1),
     ok = vmq_plugin_mgr:disable_module_plugin(
-           auth_on_register_v1, ?MODULE, auth_on_register_ok_hook, 6).
+           auth_on_register_m5, ?MODULE, auth_on_register_ok_hook, 6).
 
 reauthenticate(_Config) ->
     %% If the Client supplied an Authentication Method in the CONNECT
@@ -278,11 +278,11 @@ reauthenticate(_Config) ->
     %% Network Connection [MQTT-4.12.1-1]
 
     ok = vmq_plugin_mgr:enable_module_plugin(
-           auth_on_register_v1, ?MODULE, auth_on_register_ok_hook, 6),
+           auth_on_register_m5, ?MODULE, auth_on_register_ok_hook, 6),
     ok = vmq_plugin_mgr:enable_module_plugin(
-           on_auth_v1, ?MODULE, on_auth_hook, 1),
+           on_auth_m5, ?MODULE, on_auth_hook, 1),
     ok = vmq_plugin_mgr:enable_module_plugin(
-           auth_on_publish_v1, ?MODULE, auth_on_publish_after_reauth, 7),
+           auth_on_publish_m5, ?MODULE, auth_on_publish_after_reauth, 7),
 
     ClientId = "client-enhanced-re-auth",
     Connect = packetv5:gen_connect(ClientId, [{keepalive, 10},
@@ -312,11 +312,11 @@ reauthenticate(_Config) ->
     ok = gen_tcp:close(Socket),
 
     ok = vmq_plugin_mgr:disable_module_plugin(
-           auth_on_publish_v1, ?MODULE, auth_on_publish_after_reauth, 7),
+           auth_on_publish_m5, ?MODULE, auth_on_publish_after_reauth, 7),
     ok = vmq_plugin_mgr:disable_module_plugin(
-           on_auth_v1, ?MODULE, on_auth_hook, 1),
+           on_auth_m5, ?MODULE, on_auth_hook, 1),
     ok = vmq_plugin_mgr:disable_module_plugin(
-           auth_on_register_v1, ?MODULE, auth_on_register_ok_hook, 6).
+           auth_on_register_m5, ?MODULE, auth_on_register_ok_hook, 6).
 
 reauthenticate_server_rejects(_Config) ->
     %% If the re-authentication fails, the Client or Server SHOULD

--- a/apps/vmq_server/test/vmq_publish_SUITE.erl
+++ b/apps/vmq_server/test/vmq_publish_SUITE.erl
@@ -850,28 +850,28 @@ enable_on_subscribe() ->
            auth_on_subscribe, ?MODULE, hook_auth_on_subscribe, 3),
     ok = vmq_plugin_mgr:enable_module_plugin(
            auth_on_subscribe, ?MODULE, hook_auth_on_subscribe, 3,
-           [{compat, {auth_on_subscribe_v1, vmq_plugin_compat_v1_v0,
+           [{compat, {auth_on_subscribe_m5, vmq_plugin_compat_m5,
                      convert, 4}}]).
 enable_on_publish() ->
     ok = vmq_plugin_mgr:enable_module_plugin(
            auth_on_publish, ?MODULE, hook_auth_on_publish, 6),
     ok = vmq_plugin_mgr:enable_module_plugin(
            auth_on_publish, ?MODULE, hook_auth_on_publish, 6,
-           [{compat, {auth_on_publish_v1, vmq_plugin_compat_v1_v0,
+           [{compat, {auth_on_publish_m5, vmq_plugin_compat_m5,
                     convert, 7}}]).
 disable_on_subscribe() ->
     ok = vmq_plugin_mgr:disable_module_plugin(
            auth_on_subscribe, ?MODULE, hook_auth_on_subscribe, 3),
     ok = vmq_plugin_mgr:disable_module_plugin(
            auth_on_subscribe, ?MODULE, hook_auth_on_subscribe, 3,
-           [{compat, {auth_on_subscribe_v1, vmq_plugin_compat_v1_v0,
+           [{compat, {auth_on_subscribe_m5, vmq_plugin_compat_m5,
                       convert, 4}}]).
 disable_on_publish() ->
     ok = vmq_plugin_mgr:disable_module_plugin(
            auth_on_publish, ?MODULE, hook_auth_on_publish, 6),
     ok = vmq_plugin_mgr:disable_module_plugin(
            auth_on_publish, ?MODULE, hook_auth_on_publish, 6,
-           [{compat, {auth_on_publish_v1, vmq_plugin_compat_v1_v0,
+           [{compat, {auth_on_publish_m5, vmq_plugin_compat_m5,
                       convert, 7}}]).
 
 

--- a/apps/vmq_server/test/vmq_retain_SUITE.erl
+++ b/apps/vmq_server/test/vmq_retain_SUITE.erl
@@ -481,26 +481,26 @@ enable_on_subscribe() ->
            auth_on_subscribe, ?MODULE, hook_auth_on_subscribe, 3),
     ok = vmq_plugin_mgr:enable_module_plugin(
            auth_on_subscribe, ?MODULE, hook_auth_on_subscribe, 3,
-           [{compat, {auth_on_subscribe_v1, vmq_plugin_compat_v1_v0,
+           [{compat, {auth_on_subscribe_m5, vmq_plugin_compat_m5,
                      convert, 4}}]).
 enable_on_publish() ->
     ok = vmq_plugin_mgr:enable_module_plugin(
            auth_on_publish, ?MODULE, hook_auth_on_publish, 6),
     ok = vmq_plugin_mgr:enable_module_plugin(
            auth_on_publish, ?MODULE, hook_auth_on_publish, 6,
-           [{compat, {auth_on_publish_v1, vmq_plugin_compat_v1_v0,
+           [{compat, {auth_on_publish_m5, vmq_plugin_compat_m5,
                     convert, 7}}]).
 disable_on_subscribe() ->
     ok = vmq_plugin_mgr:disable_module_plugin(
            auth_on_subscribe, ?MODULE, hook_auth_on_subscribe, 3),
     ok = vmq_plugin_mgr:disable_module_plugin(
            auth_on_subscribe, ?MODULE, hook_auth_on_subscribe, 3,
-           [{compat, {auth_on_subscribe_v1, vmq_plugin_compat_v1_v0,
+           [{compat, {auth_on_subscribe_m5, vmq_plugin_compat_m5,
                       convert, 4}}]).
 disable_on_publish() ->
     ok = vmq_plugin_mgr:disable_module_plugin(
            auth_on_publish, ?MODULE, hook_auth_on_publish, 6),
     ok = vmq_plugin_mgr:disable_module_plugin(
            auth_on_publish, ?MODULE, hook_auth_on_publish, 6,
-           [{compat, {auth_on_publish_v1, vmq_plugin_compat_v1_v0,
+           [{compat, {auth_on_publish_m5, vmq_plugin_compat_m5,
                       convert, 7}}]).

--- a/apps/vmq_server/test/vmq_subscribe_SUITE.erl
+++ b/apps/vmq_server/test/vmq_subscribe_SUITE.erl
@@ -424,26 +424,26 @@ enable_on_subscribe() ->
            auth_on_subscribe, ?MODULE, hook_auth_on_subscribe, 3),
     ok = vmq_plugin_mgr:enable_module_plugin(
            auth_on_subscribe, ?MODULE, hook_auth_on_subscribe, 3,
-           [{compat, {auth_on_subscribe_v1, vmq_plugin_compat_v1_v0,
+           [{compat, {auth_on_subscribe_m5, vmq_plugin_compat_m5,
                      convert, 4}}]).
 enable_on_publish() ->
     ok = vmq_plugin_mgr:enable_module_plugin(
            auth_on_publish, ?MODULE, hook_auth_on_publish, 6),
     ok = vmq_plugin_mgr:enable_module_plugin(
            auth_on_publish, ?MODULE, hook_auth_on_publish, 6,
-           [{compat, {auth_on_publish_v1, vmq_plugin_compat_v1_v0,
+           [{compat, {auth_on_publish_m5, vmq_plugin_compat_m5,
                     convert, 7}}]).
 disable_on_subscribe() ->
     ok = vmq_plugin_mgr:disable_module_plugin(
            auth_on_subscribe, ?MODULE, hook_auth_on_subscribe, 3),
     ok = vmq_plugin_mgr:disable_module_plugin(
            auth_on_subscribe, ?MODULE, hook_auth_on_subscribe, 3,
-           [{compat, {auth_on_subscribe_v1, vmq_plugin_compat_v1_v0,
+           [{compat, {auth_on_subscribe_m5, vmq_plugin_compat_m5,
                       convert, 4}}]).
 disable_on_publish() ->
     ok = vmq_plugin_mgr:disable_module_plugin(
            auth_on_publish, ?MODULE, hook_auth_on_publish, 6),
     ok = vmq_plugin_mgr:disable_module_plugin(
            auth_on_publish, ?MODULE, hook_auth_on_publish, 6,
-           [{compat, {auth_on_publish_v1, vmq_plugin_compat_v1_v0,
+           [{compat, {auth_on_publish_m5, vmq_plugin_compat_m5,
                       convert, 7}}]).

--- a/rebar.lock
+++ b/rebar.lock
@@ -102,7 +102,7 @@
  {<<"unicode_util_compat">>,{pkg,<<"unicode_util_compat">>,<<"0.2.0">>},2},
  {<<"vernemq_dev">>,
   {git,"git://github.com/larshesel/vernemq_dev.git",
-       {ref,"2a5aa8885ac843ea4967d535bde6175aeb18bbe5"}},
+       {ref,"05b5595aa858fb966ff587edb519ad554dc3689e"}},
   0}]}.
 [
 {pkg_hash,[


### PR DESCRIPTION
As discussed a while back I think it's confusing to call the new hooks `_v1` introduced in the mqtt5 fsm. They are simply new hooks needed to support the mqtt version 5 protocol and not new versions of the old hooks with the similar names. With this change we can later add new hook versions without it being too confusing...

This depends on the same change in the `vernemq_dev` repo: https://github.com/larshesel/vernemq_dev/pull/1.

Are the `_m5` postfix acceptable for you?