### PR TITLE
Use git hashes in non-tagged package names (nightly builds)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -173,18 +173,7 @@ get_dist_deps = mkdir distdir && \
                 LC_ALL=POSIX && export LC_ALL && sort $(MANIFEST_FILE) > $(MANIFEST_FILE).tmp && mv $(MANIFEST_FILE).tmp $(MANIFEST_FILE);
 
 
-# Name resulting directory & tar file based on current status of the git tag
-# If it is a tagged release (PKG_VERSION == MAJOR_VERSION), use the toplevel
-#   tag as the package name, otherwise generate a unique hash of all the
-#   dependencies revisions to make the package name unique.
-#   This enables the toplevel repository package to change names
-#   when underlying dependencies change.
-NAME_HASH = $(shell git hash-object distdir/$(CLONEDIR)/$(MANIFEST_FILE) 2>/dev/null | cut -c 1-8)
-ifeq ($(REVISION), $(MAJOR_VERSION))
 PKG_ID := $(REPO_TAG)
-else
-PKG_ID = $(REPO)-$(MAJOR_VERSION)-$(NAME_HASH)
-endif
 
 # To ensure a clean build, copy the CLONEDIR at a specific tag to a new directory
 #  which will be the basis of the src tar file (and packages)

--- a/changelog.md
+++ b/changelog.md
@@ -22,6 +22,11 @@
 - Fix issue with PUBREL frames retried after client reconnects (#762).
 - Refactor and cleanup retry mechanism.
 - Warn about deprecated setting `message_size_limit` only when it has been defined.
+- Change build script so nightly packages will have names on the form
+  `vernemq_1.4.0-10-gde1b1f5-1_amd64.deb`, where `de1b1f5` refers to the commit
+  hash from which the package was built and `10` is the number of commits since
+  the latest tag. This makes it much easier to reason about nightly builds and
+  the features they contain.
 
 ## VerneMQ 1.4.0
 


### PR DESCRIPTION
This makes it easier to reason about nightly bulds and the features
they contain.

Hopefully this doesn't break our download page as this means package names now can contain one more `-` (now: `vernemq_1.4.0-10-gde1b1f5-1_amd64.deb`, before: `vernemq_1.4.0-b994c136-1_amd64.db`). Looking over the code I don't think this will be a problem, though.