### PR TITLE
Don't timeout when calling a Lua script function.

### DIFF
--- a/apps/vmq_diversity/src/vmq_diversity_script.erl
+++ b/apps/vmq_diversity/src/vmq_diversity_script.erl
@@ -59,7 +59,7 @@ call_function(Pid, Function, Args) ->
     %% error in the plugin code can crash session/queue. As the Lua
     %% support should provide a sandboxed environment we saveguard
     %% calls into the Lua environment.
-    case catch gen_server:call(Pid, {call_function, Function, Args}) of
+    case catch gen_server:call(Pid, {call_function, Function, Args}, infinity) of
         {'EXIT', Reason} ->
             lager:error("can't call into Lua sandbox for function ~p due to ~p", [Function, Reason]),
             error;

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Fix issue when calling a function in a Lua script that requires more time to complete than the default `gen_server` timeout (#589). 
+
 ## VerneMQ 1.5.0
 
 - Fix issue in the bridge preventing it from reconnecting after a connection


### PR DESCRIPTION
Fixes #589 