### PR TITLE
Add MQTT 5.0 support to MySQL, Redis, PostgreSQL, MongoDB auth

### DIFF
--- a/apps/vmq_diversity/priv/auth/auth_commons.lua
+++ b/apps/vmq_diversity/priv/auth/auth_commons.lua
@@ -46,6 +46,18 @@ end
 
 -- included in every DB auth handler
 
+function auth_on_register_m5(reg)
+   return auth_on_register(reg)
+end
+
+function auth_on_publish_m5(pub)
+   return false
+end
+
+function auth_on_subscribe_m5(sub)
+   return false
+end
+
 function auth_on_publish(pub)
     return false
 end

--- a/apps/vmq_diversity/priv/auth/mongodb.lua
+++ b/apps/vmq_diversity/priv/auth/mongodb.lua
@@ -97,7 +97,11 @@ hooks = {
     auth_on_subscribe = auth_on_subscribe,
     on_unsubscribe = on_unsubscribe,
     on_client_gone = on_client_gone,
-    on_client_offline = on_client_offline
+    on_client_offline = on_client_offline,
+
+    auth_on_register_m5 = auth_on_register_m5,
+    auth_on_publish_m5 = auth_on_publish_m5,
+    auth_on_subscribe_m5 = auth_on_subscribe_m5,
 }
 
 

--- a/apps/vmq_diversity/priv/auth/mysql.lua
+++ b/apps/vmq_diversity/priv/auth/mysql.lua
@@ -95,5 +95,9 @@ hooks = {
     auth_on_subscribe = auth_on_subscribe,
     on_unsubscribe = on_unsubscribe,
     on_client_gone = on_client_gone,
-    on_client_offline = on_client_offline
+    on_client_offline = on_client_offline,
+
+    auth_on_register_m5 = auth_on_register_m5,
+    auth_on_publish_m5 = auth_on_publish_m5,
+    auth_on_subscribe_m5 = auth_on_subscribe_m5,
 }

--- a/apps/vmq_diversity/priv/auth/postgres.lua
+++ b/apps/vmq_diversity/priv/auth/postgres.lua
@@ -110,5 +110,9 @@ hooks = {
     auth_on_subscribe = auth_on_subscribe,
     on_unsubscribe = on_unsubscribe,
     on_client_gone = on_client_gone,
-    on_client_offline = on_client_offline
+    on_client_offline = on_client_offline,
+
+    auth_on_register_m5 = auth_on_register_m5,
+    auth_on_publish_m5 = auth_on_publish_m5,
+    auth_on_subscribe_m5 = auth_on_subscribe_m5,
 }

--- a/apps/vmq_diversity/priv/auth/redis.lua
+++ b/apps/vmq_diversity/priv/auth/redis.lua
@@ -63,5 +63,9 @@ hooks = {
     auth_on_subscribe = auth_on_subscribe,
     on_unsubscribe = on_unsubscribe,
     on_client_gone = on_client_gone,
-    on_client_offline = on_client_offline
+    on_client_offline = on_client_offline,
+
+    auth_on_register_m5 = auth_on_register_m5,
+    auth_on_publish_m5 = auth_on_publish_m5,
+    auth_on_subscribe_m5 = auth_on_subscribe_m5,
 }

--- a/apps/vmq_diversity/src/vmq_diversity_utils.erl
+++ b/apps/vmq_diversity/src/vmq_diversity_utils.erl
@@ -15,6 +15,32 @@
 -module(vmq_diversity_utils).
 -compile([nowarn_export_all, export_all]).
 
+%% @doc change modifiers into a canonical form so it can be run
+%% through the modifier checker.
+normalize_modifiers(auth_on_subscribe_m5, Mods) ->
+    Mods1 =
+    lists:map(
+      fun({topics, Topics}) ->
+              {topics, normalize_subscribe_topics(Topics)}
+      end, Mods),
+    maps:from_list(Mods1);
+normalize_modifiers(auth_on_register_m5, Mods) ->
+    maps:from_list(Mods);
+normalize_modifiers(auth_on_publish_m5, Mods) ->
+    maps:from_list(Mods);
+normalize_modifiers(auth_on_subscribe, Mods) ->
+    normalize_subscribe_topics(Mods);
+normalize_modifiers(_Hook, Mods) ->
+    Mods.
+
+normalize_subscribe_topics(Topics0) ->
+    lists:map(
+      fun([T, [Q, SubOpts]]) ->
+              {T, {convert(Q), maps:from_list(SubOpts)}};
+         ([T, Q]) ->
+              {T, convert(Q)}
+      end, Topics0).
+
 convert(Val) when is_list(Val) ->
     convert_list(Val, []);
 convert(Val) when is_number(Val) ->

--- a/apps/vmq_diversity/test/vmq_diversity_plugin_SUITE.erl
+++ b/apps/vmq_diversity/test/vmq_diversity_plugin_SUITE.erl
@@ -8,20 +8,8 @@
          all/0
         ]).
 
--export([auth_on_register_test/1,
-         auth_on_publish_test/1,
-         auth_on_subscribe_test/1,
-         on_register_test/1,
-         on_publish_test/1,
-         on_subscribe_test/1,
-         on_unsubscribe_test/1,
-         on_deliver_test/1,
-         on_offline_message_test/1,
-         on_client_wakeup_test/1,
-         on_client_offline_test/1,
-         on_client_gone_test/1,
-         auth_on_register_undefined_creds_test/1
-        ]).
+-compile(export_all).
+-compile(nowarn_export_all).
 
 %% ===================================================================
 %% common_test callbacks
@@ -58,7 +46,11 @@ all() ->
      on_client_wakeup_test,
      on_client_offline_test,
      on_client_gone_test,
-     auth_on_register_undefined_creds_test
+     auth_on_register_undefined_creds_test,
+
+     auth_on_register_m5_test,
+     auth_on_subscribe_m5_test,
+     auth_on_publish_m5_test
     ].
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -74,6 +66,19 @@ auth_on_register_test(_) ->
     {ok, [{subscriber_id, {"override-mountpoint", <<"override-client-id">>}}]} = vmq_plugin:all_till_ok(auth_on_register,
                       [peer(), changed_subscriber_id(), username(), password(), true]).
 
+props() ->
+    #{p_user_property => [{<<"key1">>, <<"val1">>}]}.
+
+auth_on_register_m5_test(_) ->
+    ok = vmq_plugin:all_till_ok(auth_on_register_m5,
+                      [peer(), allowed_subscriber_id(), username(), password(), true, props()]),
+    {error, error} = vmq_plugin:all_till_ok(auth_on_register_m5,
+                      [peer(), not_allowed_subscriber_id(), username(), password(), true, #{}]),
+    {error, chain_exhausted} = vmq_plugin:all_till_ok(auth_on_register_m5,
+                      [peer(), ignored_subscriber_id(), username(), password(), true, #{}]),
+    {ok, #{subscriber_id := {"override-mountpoint", <<"override-client-id">>}}} = vmq_plugin:all_till_ok(auth_on_register_m5,
+                      [peer(), changed_subscriber_id(), username(), password(), true, #{}]).
+
 auth_on_publish_test(_) ->
     ok = vmq_plugin:all_till_ok(auth_on_publish,
                       [username(), allowed_subscriber_id(), 1, topic(), payload(), false]),
@@ -83,6 +88,17 @@ auth_on_publish_test(_) ->
                       [username(), ignored_subscriber_id(), 1, topic(), payload(), false]),
     {ok, [{topic, [<<"hello">>, <<"world">>]}]} = vmq_plugin:all_till_ok(auth_on_publish,
                       [username(), changed_subscriber_id(), 1, topic(), payload(), false]).
+
+auth_on_publish_m5_test(_) ->
+    ok = vmq_plugin:all_till_ok(auth_on_publish_m5,
+                      [username(), allowed_subscriber_id(), 1, topic(), payload(), false, props()]),
+    {error, error} = vmq_plugin:all_till_ok(auth_on_publish_m5,
+                      [username(), not_allowed_subscriber_id(), 1, topic(), payload(), false, props()]),
+    {error, chain_exhausted} = vmq_plugin:all_till_ok(auth_on_publish_m5,
+                      [username(), ignored_subscriber_id(), 1, topic(), payload(), false, props()]),
+    {ok, #{topic := [<<"hello">>, <<"world">>]}} = vmq_plugin:all_till_ok(auth_on_publish_m5,
+                      [username(), changed_subscriber_id(), 1, topic(), payload(), false, props()]).
+
 auth_on_subscribe_test(_) ->
     ok = vmq_plugin:all_till_ok(auth_on_subscribe,
                       [username(), allowed_subscriber_id(), [{topic(), 1}]]),
@@ -92,6 +108,18 @@ auth_on_subscribe_test(_) ->
                       [username(), ignored_subscriber_id(), [{topic(), 1}]]),
     {ok, [{[<<"hello">>, <<"world">>], 2}]} = vmq_plugin:all_till_ok(auth_on_subscribe,
                       [username(), changed_subscriber_id(), [{topic(), 1}]]).
+
+auth_on_subscribe_m5_test(_) ->
+    ok = vmq_plugin:all_till_ok(auth_on_subscribe_m5,
+                      [username(), allowed_subscriber_id(), [{topic(), {1, subopts()}}], props()]),
+    {error, error} = vmq_plugin:all_till_ok(auth_on_subscribe_m5,
+                      [username(), not_allowed_subscriber_id(), [{topic(), {1, subopts()}}], props()]),
+    {error, chain_exhausted} = vmq_plugin:all_till_ok(auth_on_subscribe_m5,
+                      [username(), ignored_subscriber_id(), [{topic(), {1, subopts()}}], props()]),
+    {ok, #{topics := [{[<<"hello">>, <<"world">>], {2, #{rap := true}}}]}} = vmq_plugin:all_till_ok(auth_on_subscribe_m5,
+                      [username(), changed_subscriber_id(), [{topic(), {1, subopts()}}], props()]).
+
+
 on_register_test(_) ->
     [next] = vmq_plugin:all(on_register,
                             [peer(), allowed_subscriber_id(), username()]).
@@ -147,3 +175,6 @@ username() -> <<"test-user">>.
 password() -> <<"test-password">>.
 topic() -> [<<"test">>, <<"topic">>].
 payload() -> <<"hello world">>.
+subopts() ->
+    #{rap => true,
+      no_local => false}.

--- a/apps/vmq_webhooks/src/vmq_webhooks_plugin.erl
+++ b/apps/vmq_webhooks/src/vmq_webhooks_plugin.erl
@@ -780,8 +780,8 @@ normalize_modifiers(auth_on_register, Mods, _) ->
 normalize_modifiers(auth_on_subscribe, Topics, _) ->
     lists:map(
       fun(PL) ->
-              [proplists:get_value(<<"topic">>, PL),
-               proplists:get_value(<<"qos">>, PL)]
+              {proplists:get_value(<<"topic">>, PL),
+               proplists:get_value(<<"qos">>, PL)}
       end,
       Topics);
 normalize_modifiers(auth_on_publish, Mods, EOpts) ->

--- a/changelog.md
+++ b/changelog.md
@@ -39,11 +39,13 @@
   example `listener.tcp.allowed_protocol_versions=3,4,5` would enable MQTT
   version 3.1, 3.1.1 and 5.0 on the TCP listener.
 
-  MQTTv5 support has also been added to the `vmq_passwd`, `vmq_acl`,
-  `vmq_webhooks` plugins.
+  MQTTv5 support has been added to the `vmq_passwd`, `vmq_acl`, `vmq_webhooks`
+  plugins as well as the parts of the `vmq_diversity` plugin to support the
+  MySQL, PostgreSQL, Redis and MongoDB authentication and authorization
+  mechanisms. The Lua scripting language provided by the `vmq_diversity` plugin
+  does not yet expose all MQTT 5.0 plugin hooks.
 
-  The `vmq_bridge` and `vmq_diversity` plugins currently have no support for
-  MQTTv5.
+  The `vmq_bridge` plugin currently has no support for MQTTv5.
 
   !! Note !! that all MQTTv5 related features and plugins are in BETA and may
   still change if needed.


### PR DESCRIPTION
This adds support for using the `vmq_diversity` database authentication drivers with MQTT 5.0 clients.

Note we now normalize the output of the `auth_on_subscribe` lua hook so we only have to handle the canonical format in the `vmq_plugin_util:check_modifiers/2` function - before we handled whatever came out of the lua hook, see https://github.com/erlio/vernemq/compare/master...larshesel:add-mqttv5-support-to-existing-plugins?expand=1#diff-f6d817c136d8a74d88f87d39403c3061L296

Note, the rest of the MQTT 5.0 hooks haven't been exposed to Lua yet.