### PR TITLE
Added Solaris build fixes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -70,6 +70,7 @@
 - Fix ordering bug in webhook subscribe topic authentication and topic rewrites
   (#823)
 - Fix issue when terminating the `vmq_server` application (#828).
+- Make VerneMQ build on SmartOS / Illumos / Solaris.
 
 ## VerneMQ 1.5.0
 

--- a/rebar.config
+++ b/rebar.config
@@ -31,13 +31,6 @@
                {post_hooks,
                 [{"(linux|darwin|solaris)", clean, "make -C c_src clean"},
                  {"(freebsd)", clean, "gmake -C c_src clean"}]}
-              ]},
-             {override, bcrypt,
-              [
-               %% Pegging the pc (port-compiler) to a known working
-               %% version as newer (v1.9.1) doesn't seem to work. See
-               %% https://github.com/blt/port_compiler/issues/48.
-               {plugins, [{pc, "1.8.0"}]}
               ]}
             ]}.
 

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,5 +1,5 @@
 {"1.1.0",
-[{<<"bcrypt">>,{pkg,<<"bcrypt">>,<<"1.0.0">>},0},
+[{<<"bcrypt">>,{pkg,<<"bcrypt">>,<<"1.0.2">>},0},
  {<<"bson">>,
   {git,"git://github.com/comtihon/bson-erlang",
        {ref,"14308ab927cfa69324742c3de720578094e0bb19"}},
@@ -68,7 +68,7 @@
   0},
  {<<"mzmetrics">>,
   {git,"git://github.com/erlio/mzmetrics.git",
-       {ref,"6687da85a8f3847ecf0968596d5d3bd9d8cdd431"}},
+       {ref,"09e42f9bf486c05a05658d94e789f3fff1e58840"}},
   0},
  {<<"node_package">>,
   {git,"git://github.com/erlio/node_package.git",
@@ -106,7 +106,7 @@
   0}]}.
 [
 {pkg_hash,[
- {<<"bcrypt">>, <<"1C0F76981D8A7B32E4DAA813408BFCA5BA8B1286196EB771F026D02C710F71C5">>},
+ {<<"bcrypt">>, <<"6735F66D3A7309AF166CE660161009B7D9B9216508B8B2E6A0A9090AF35CB757">>},
  {<<"certifi">>, <<"C3904F192BD5284E5B13F20DB3CEAC9626E14EEACFBB492E19583CF0E37B22BE">>},
  {<<"cowboy">>, <<"A324A8DF9F2316C833A470D918AAF73AE894278B8AA6226CE7A9BF699388F878">>},
  {<<"cowlib">>, <<"9D769A1D062C9C3AC753096F868CA121E2730B9A377DE23DEC0F7E08B1DF84EE">>},


### PR DESCRIPTION
This patch makes VerneMQ buildable on SmartOS / Illumos / Solaris. 

The 1.0.0 to 1.0.2 bump in the bcrypt library adds Solaris support the the bcrypt library. It doesn't change anything else in the bcrypt library. It's a 2 minor version jump because the first release did not fix all Solaris build issues in the bcrypt library (as you see here: https://github.com/erlangpack/bcrypt ).

I think it will be best to hold off merging this PR until this PR: https://github.com/erlio/mzmetrics/pull/2 is merged first. I can then update the `mzmetrics` version in `rebar.lock` and update this PR to fix all build issues.