### PR TITLE
Upgrade vernemq_dev dependency

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -12,7 +12,7 @@
         {lager, "3.2.1"},
         {cuttlefish, {git,"git://github.com/kyorai/cuttlefish.git", {branch, "develop"}}},
         {eper, "0.94.0"},
-        {vernemq_dev, {git, "git://github.com/larshesel/vernemq_dev.git", {branch, "mqtt5-preview"}}},
+        {vernemq_dev, {git, "git://github.com/erlio/vernemq_dev.git", {branch, "master"}}},
 
         {node_package, {git,"git://github.com/erlio/node_package.git", {branch, "rebar3x-support"}}},
         {lager_syslog, {git, "git://github.com/basho/lager_syslog.git", {tag, "3.0.1"}}},

--- a/rebar.lock
+++ b/rebar.lock
@@ -101,8 +101,8 @@
   1},
  {<<"unicode_util_compat">>,{pkg,<<"unicode_util_compat">>,<<"0.2.0">>},2},
  {<<"vernemq_dev">>,
-  {git,"git://github.com/larshesel/vernemq_dev.git",
-       {ref,"e55dd3d798d3532752ff69b5e8704977396aec43"}},
+  {git,"git://github.com/erlio/vernemq_dev.git",
+       {ref,"83eec4d1aed2cdd351081fcb5b7203dfb4acbbd9"}},
   0}]}.
 [
 {pkg_hash,[


### PR DESCRIPTION
This includes all the mqtt5 hooks as well as the `dropped_message` hook.

Note we need to merge this to fix master which is currently broken - before this we were using the `mqtt5-preview` branch in my repo and I accidentally rebased that so the commit in the rebar.lock file no longer exists... 