### PR TITLE
Update m5 hooks

### DIFF
--- a/apps/vmq_mqtt5_demo_plugin/src/vmq_mqtt5_demo_plugin.erl
+++ b/apps/vmq_mqtt5_demo_plugin/src/vmq_mqtt5_demo_plugin.erl
@@ -44,7 +44,7 @@ auth_on_register_m5(Peer,SubscriberId,Username,Password,CleanStart,Properties) -
 
 auth_on_register_m5_(_Peer,_SubscriberId,<<"quota_exceeded">>,_Password,_CleanStart,_Properties) ->
     {error, #{reason_code => ?QUOTA_EXCEEDED,
-              properties => #{?P_REASON_STRING => <<"You have exceeded your quota">>}}};
+              reason_string => <<"You have exceeded your quota">>}};
 auth_on_register_m5_(_Peer,_SubscriberId,_Username,_Password,_CleanStart,_Properties) ->
     ok.
 
@@ -61,7 +61,7 @@ auth_on_publish_m5(Username,SubscriberId,QoS,Topic,Payload,IsRetain,Properties) 
 
 auth_on_publish_m5_(_Username,_SubscriberId,_QoS,[<<"invalid">>, <<"topic">>],_Payload,_IsRetain,_Properties) ->
     {error, #{reason_code => ?TOPIC_NAME_INVALID,
-              properties => #{?P_REASON_STRING => <<"Invalid topic name">>}}};
+              reason_string => <<"Invalid topic name">>}};
 auth_on_publish_m5_(_Username,_SubscriberId,_QoS,_Topic,_Payload,_IsRetain,_Properties) ->
     ok.
 
@@ -80,8 +80,8 @@ auth_on_subscribe_m5_(_Username,_SubscriberId,
                       [{[<<"suback">>,<<"withprops">>], _}] = Topics,
                       _Properties) ->
     {ok, #{topics => Topics,
-           properties => #{?P_USER_PROPERTY => [{<<"key">>, <<"val">>}],
-                           ?P_REASON_STRING => <<"successful subscribe">>}}};
+           user_property => [{<<"key">>, <<"val">>}],
+           reason_string => <<"successful subscribe">>}};
 auth_on_subscribe_m5_(_Username,_SubscriberId,_Topics,_Properties) ->
     ok.
 
@@ -97,8 +97,8 @@ on_unsubscribe_m5_(_Username,_SubscriberId,
                    [[<<"unsuback">>,<<"withprops">>]] = Topics,
                    _Properties) ->
     {ok, #{topics => Topics,
-           properties => #{?P_USER_PROPERTY => [{<<"key">>, <<"val">>}],
-                           ?P_REASON_STRING => <<"Unsubscribe worked">>}}};
+           user_property => [{<<"key">>, <<"val">>}],
+           reason_string => <<"Unsubscribe worked">>}};
 on_unsubscribe_m5_(_Username,_SubscriberId,_Topics,_Properties) ->
     ok.
 
@@ -114,20 +114,20 @@ on_auth_m5_(_Username, _SubscriberId,
             #{?P_AUTHENTICATION_METHOD := <<"method1">>,
               ?P_AUTHENTICATION_DATA := <<"client1">>}) ->
     {ok, #{reason_code => ?CONTINUE_AUTHENTICATION,
-           properties => #{?P_AUTHENTICATION_METHOD => <<"method1">>,
-                           ?P_AUTHENTICATION_DATA => <<"server1">>}}};
+           auth_method => <<"method1">>,
+           auth_data => <<"server1">>}};
 on_auth_m5_(_Username, _SubscriberId,
             #{?P_AUTHENTICATION_METHOD := <<"method1">>,
               ?P_AUTHENTICATION_DATA := <<"client2">>}) ->
     {ok, #{reason_code => ?SUCCESS,
-           properties => #{?P_AUTHENTICATION_METHOD => <<"method1">>,
-                           ?P_AUTHENTICATION_DATA => <<"server2">>}}};
+           auth_method => <<"method1">>,
+           auth_data => <<"server2">>}};
 on_auth_m5_(_Username, _SubscriberId,
             #{?P_AUTHENTICATION_METHOD := <<"method1">>,
               ?P_AUTHENTICATION_DATA := <<"baddata">>}) ->
     %% any other auth method we just reject.
     {error, #{reason_code => ?NOT_AUTHORIZED,
-              properties => #{?P_REASON_STRING => <<"Bad authentication data: baddata">>}}};
+              reason_string => <<"Bad authentication data: baddata">>}};
 on_auth_m5_(_Username, _SubscriberId, _Props) ->
     {error, unexpected_authentication_attempt}.
 

--- a/apps/vmq_server/src/vmq_mqtt_fsm.erl
+++ b/apps/vmq_server/src/vmq_mqtt_fsm.erl
@@ -62,7 +62,7 @@
           max_client_id_size=100            :: non_neg_integer(),
 
           %% changeable by auth_on_register
-          shared_subscription_policy=prefer_local :: sg_policy(),
+          shared_subscription_policy=prefer_local :: shared_sub_policy(),
           max_inflight_messages=20          :: non_neg_integer(), %% 0 means unlimited
           max_message_rate=0                :: non_neg_integer(), %% 0 means unlimited
           retry_interval=20000              :: pos_integer(),

--- a/apps/vmq_server/src/vmq_server.hrl
+++ b/apps/vmq_server/src/vmq_server.hrl
@@ -16,7 +16,7 @@
           qos                   :: qos(),
           mountpoint            :: mountpoint(),
           persisted=false       :: flag(),
-          sg_policy=prefer_local:: sg_policy(),
+          sg_policy=prefer_local:: shared_sub_policy(),
           %% TODOv5: need to import the mqtt5 property typespec?
           properties=#{}        :: map(),
           expiry_ts             :: undefined

--- a/apps/vmq_server/src/vmq_server.hrl
+++ b/apps/vmq_server/src/vmq_server.hrl
@@ -7,7 +7,6 @@
 -type msg_expiry_ts() :: {expire_after, non_neg_integer()}
                        | {non_neg_integer(), non_neg_integer()}.
 
--type sg_policy() :: prefer_local | local_only | random.
 -record(vmq_msg, {
           msg_ref               :: msg_ref() | 'undefined', % OTP-12719
           routing_key           :: routing_key() | 'undefined',

--- a/apps/vmq_server/test/vmq_mqtt5_SUITE.erl
+++ b/apps/vmq_server/test/vmq_mqtt5_SUITE.erl
@@ -340,20 +340,22 @@ on_auth_bad_method_hook(_, _, #{p_authentication_method := _, p_authentication_d
 
 on_auth_hook(_, _, #{p_authentication_method := ?AUTH_METHOD, p_authentication_data := <<"Client1">>}) ->
     {ok, #{reason_code => ?CONTINUE_AUTHENTICATION,
-           properties =>
-               #{p_authentication_method => ?AUTH_METHOD, p_authentication_data => <<"Server1">>}}};
+           auth_method => ?AUTH_METHOD,
+           auth_data => <<"Server1">>}};
 on_auth_hook(_, _, #{p_authentication_method := ?AUTH_METHOD, p_authentication_data := <<"Client2">>}) ->
     {ok, #{reason_code => ?CONTINUE_AUTHENTICATION,
-           properties =>
-               #{p_authentication_method => ?AUTH_METHOD, p_authentication_data => <<"Server2">>}}};
+           auth_method => ?AUTH_METHOD,
+           auth_data => <<"Server2">>}};
 on_auth_hook(_, _, #{p_authentication_method := ?AUTH_METHOD, p_authentication_data := <<"Client3">>}) ->
     %% return ok which will trigger the connack being sent to the
     %% client *or* an AUTH ok
     {ok, #{reason_code => ?SUCCESS,
-           properties => #{p_authentication_method => ?AUTH_METHOD, p_authentication_data => <<"ServerFinal">>}}};
+           auth_method => ?AUTH_METHOD,
+           auth_data => <<"ServerFinal">>}};
 on_auth_hook(_, _, #{p_authentication_method := ?AUTH_METHOD, p_authentication_data := <<"Reauth">>}) ->
     {ok, #{reason_code => ?SUCCESS,
-           properties => #{p_authentication_method => ?AUTH_METHOD, p_authentication_data => <<"ReauthOK">>}}}.
+           auth_method => ?AUTH_METHOD,
+           auth_data => <<"ReauthOK">>}}.
 
 auth_on_publish_after_reauth(undefined, _, 1, [<<"some">>, <<"topic">>], <<"some payload">>, false, _) ->
     ok.

--- a/apps/vmq_server/test/vmq_mqtt5_demo_plugin_SUITE.erl
+++ b/apps/vmq_server/test/vmq_mqtt5_demo_plugin_SUITE.erl
@@ -147,8 +147,7 @@ auth_with_properties(Cfg) ->
                                        ?P_AUTHENTICATION_DATA => <<"baddata">>}),
     DisconnectWrongAuth =
         packetv5:gen_disconnect(?M5_NOT_AUTHORIZED,
-                                #{?P_REASON_STRING =>
-                                      <<"Bad authentication data: baddata">>}),
+                                #{?P_REASON_STRING => <<"Bad authentication data: baddata">>}),
     ok = gen_tcp:send(Socket, AuthOutWrong),
     ok = packetv5:expect_frame(Socket, DisconnectWrongAuth),
     {error, closed} = gen_tcp:recv(Socket, 0, 100).

--- a/rebar.lock
+++ b/rebar.lock
@@ -102,7 +102,7 @@
  {<<"unicode_util_compat">>,{pkg,<<"unicode_util_compat">>,<<"0.2.0">>},2},
  {<<"vernemq_dev">>,
   {git,"git://github.com/erlio/vernemq_dev.git",
-       {ref,"83eec4d1aed2cdd351081fcb5b7203dfb4acbbd9"}},
+       {ref,"6e41cce7d8a1dfd414782536e0c71bee0f04f5e3"}},
   0}]}.
 [
 {pkg_hash,[


### PR DESCRIPTION
This PR changes the hooks according to erlio/vernemq_dev#6: Properties are no longer passed directly from hook implementations, but are created in the FSM as needed. I'm sure we can come up with something nicer and easier on the eye than my `maps:fold` functions for picking the modifiers which go into the properties.

Note the `sg_policy()` type was moved to the erlio/vernemq_dev repo and renamed to `shared_sub_policy()`.