### PR TITLE
Improve error messages returned from `vmq_diversity`

### DIFF
--- a/apps/vmq_diversity/src/vmq_diversity_mysql.erl
+++ b/apps/vmq_diversity/src/vmq_diversity_mysql.erl
@@ -53,7 +53,7 @@ execute(As, St) ->
                     {[false], St}
             catch
                 E:R ->
-                    lager:error("can't execute query ~p due to ~p", [BQuery, E, R]),
+                    lager:error("can't execute query ~p due to ~p:~p", [BQuery, E, R]),
                     badarg_error(execute_equery, As, St)
             end;
         _ ->

--- a/apps/vmq_diversity/src/vmq_diversity_script.erl
+++ b/apps/vmq_diversity/src/vmq_diversity_script.erl
@@ -62,7 +62,7 @@ call_function(Pid, Function, Args) ->
     case catch gen_server:call(Pid, {call_function, Function, Args}, infinity) of
         {'EXIT', Reason} ->
             lager:error("can't call into Lua sandbox for function ~p due to ~p", [Function, Reason]),
-            error;
+            {error, Reason};
         Ret ->
             Ret
     end.

--- a/apps/vmq_diversity/test/vmq_diversity_plugin_SUITE.erl
+++ b/apps/vmq_diversity/test/vmq_diversity_plugin_SUITE.erl
@@ -59,7 +59,7 @@ all() ->
 auth_on_register_test(_) ->
     ok = vmq_plugin:all_till_ok(auth_on_register,
                       [peer(), allowed_subscriber_id(), username(), password(), true]),
-    {error, error} = vmq_plugin:all_till_ok(auth_on_register,
+    {error,invalid_credentials} = vmq_plugin:all_till_ok(auth_on_register,
                       [peer(), not_allowed_subscriber_id(), username(), password(), true]),
     {error, chain_exhausted} = vmq_plugin:all_till_ok(auth_on_register,
                       [peer(), ignored_subscriber_id(), username(), password(), true]),
@@ -72,7 +72,7 @@ props() ->
 auth_on_register_m5_test(_) ->
     ok = vmq_plugin:all_till_ok(auth_on_register_m5,
                       [peer(), allowed_subscriber_id(), username(), password(), true, props()]),
-    {error, error} = vmq_plugin:all_till_ok(auth_on_register_m5,
+    {error,invalid_credentials} = vmq_plugin:all_till_ok(auth_on_register_m5,
                       [peer(), not_allowed_subscriber_id(), username(), password(), true, #{}]),
     {error, chain_exhausted} = vmq_plugin:all_till_ok(auth_on_register_m5,
                       [peer(), ignored_subscriber_id(), username(), password(), true, #{}]),
@@ -82,7 +82,7 @@ auth_on_register_m5_test(_) ->
 auth_on_publish_test(_) ->
     ok = vmq_plugin:all_till_ok(auth_on_publish,
                       [username(), allowed_subscriber_id(), 1, topic(), payload(), false]),
-    {error, error} = vmq_plugin:all_till_ok(auth_on_publish,
+    {error, not_authorized} = vmq_plugin:all_till_ok(auth_on_publish,
                       [username(), not_allowed_subscriber_id(), 1, topic(), payload(), false]),
     {error, chain_exhausted} = vmq_plugin:all_till_ok(auth_on_publish,
                       [username(), ignored_subscriber_id(), 1, topic(), payload(), false]),
@@ -92,7 +92,7 @@ auth_on_publish_test(_) ->
 auth_on_publish_m5_test(_) ->
     ok = vmq_plugin:all_till_ok(auth_on_publish_m5,
                       [username(), allowed_subscriber_id(), 1, topic(), payload(), false, props()]),
-    {error, error} = vmq_plugin:all_till_ok(auth_on_publish_m5,
+    {error, not_authorized} = vmq_plugin:all_till_ok(auth_on_publish_m5,
                       [username(), not_allowed_subscriber_id(), 1, topic(), payload(), false, props()]),
     {error, chain_exhausted} = vmq_plugin:all_till_ok(auth_on_publish_m5,
                       [username(), ignored_subscriber_id(), 1, topic(), payload(), false, props()]),
@@ -102,7 +102,7 @@ auth_on_publish_m5_test(_) ->
 auth_on_subscribe_test(_) ->
     ok = vmq_plugin:all_till_ok(auth_on_subscribe,
                       [username(), allowed_subscriber_id(), [{topic(), 1}]]),
-    {error, error} = vmq_plugin:all_till_ok(auth_on_subscribe,
+    {error, not_authorized} = vmq_plugin:all_till_ok(auth_on_subscribe,
                       [username(), not_allowed_subscriber_id(), [{topic(), 1}]]),
     {error, chain_exhausted} = vmq_plugin:all_till_ok(auth_on_subscribe,
                       [username(), ignored_subscriber_id(), [{topic(), 1}]]),
@@ -112,7 +112,7 @@ auth_on_subscribe_test(_) ->
 auth_on_subscribe_m5_test(_) ->
     ok = vmq_plugin:all_till_ok(auth_on_subscribe_m5,
                       [username(), allowed_subscriber_id(), [{topic(), {1, subopts()}}], props()]),
-    {error, error} = vmq_plugin:all_till_ok(auth_on_subscribe_m5,
+    {error, not_authorized} = vmq_plugin:all_till_ok(auth_on_subscribe_m5,
                       [username(), not_allowed_subscriber_id(), [{topic(), {1, subopts()}}], props()]),
     {error, chain_exhausted} = vmq_plugin:all_till_ok(auth_on_subscribe_m5,
                       [username(), ignored_subscriber_id(), [{topic(), {1, subopts()}}], props()]),

--- a/changelog.md
+++ b/changelog.md
@@ -77,6 +77,8 @@
 - Optimize subscribe/unsubscribe operations for large fanout cases.
 - Allow non-standard MQTT version 131 (MQTT 3.1 bridge) by default (this was
   accidentally changed in VerneMQ 1.4.0).
+- Improve error messages returned by the `vmq_diversity` plugin so it's easier
+  to understand and debug authentication and authorisation issues.
 
 ## VerneMQ 1.5.0
 


### PR DESCRIPTION
In particular improve the errors for the database authn/z plugins. Fixes #831 

Examples - before everything was `due to error`:

- script error (note that in this case there will be some earlier logged messages which may have more detail on the problem of the script error)
```
2018-09-25 07:43:40.167 [warning] <0.433.0>@vmq_mqtt_fsm:check_user:544 can't authenticate client {[],<<"test-client2">>} due to lua_script_error
```

-  database connectivity (note that in this case there are earlier log messages which reveals the underlying reason - but at least the user knows this is related to the lua scripts)
```
2018-09-25 07:29:25.643 [warning] <0.447.0>@vmq_mqtt_fsm:check_user:544 can't authenticate client {[],<<"test-client2">>} due to lua_script_unknown_error
```

- authentication error
```
2018-09-25 08:37:41.912 [warning] <0.445.0>@vmq_mqtt_fsm:check_user:538 can't authenticate client {[],<<"test-client2">>} due to invalid_credentials
```

- authorization error
```
2018-09-25 07:40:31.571 [error] <0.433.0>@vmq_mqtt_fsm:auth_on_publish:691 can't auth publish [<<"test-user">>,{[],<<"test-client2">>},1,[<<"xa">>,<<"b">>,<<"c">>],<<"hello">>,false] due to not_authorized
```