### PR TITLE
Handle the ISODate MongoDB datatype properly in Lua

### DIFF
--- a/apps/vmq_diversity/src/vmq_diversity_utils.erl
+++ b/apps/vmq_diversity/src/vmq_diversity_utils.erl
@@ -107,9 +107,15 @@ unmap([{K, Map}|Rest], Acc) when is_map(Map) ->
     unmap(Rest, [{K, unmap(Map)}|Acc]);
 unmap([{K, [Map|_] = Maps}|Rest], Acc) when is_map(Map) ->
     unmap(Rest, [{K, unmap(Maps)}|Acc]);
+unmap([{K, {A,B,C}=TS}|Rest], Acc)
+  when is_integer(A), is_integer(B), is_integer(C) ->
+    unmap(Rest, [{K, to_unixtime_millisecs(TS)}|Acc]);
 unmap([{K, V}|Rest], Acc) ->
     unmap(Rest, [{K, V}|Acc]);
 unmap([], Acc) -> lists:reverse(Acc).
+
+to_unixtime_millisecs({MegaSecs,Secs,MicroSecs}) ->
+    MegaSecs * 1000000000 + Secs * 1000 + MicroSecs div 1000.
 
 int(I) when is_integer(I) -> I;
 int(I) when is_number(I) -> round(I).

--- a/changelog.md
+++ b/changelog.md
@@ -72,6 +72,8 @@
 - Fix issue when terminating the `vmq_server` application (#828).
 - Make VerneMQ build on SmartOS / Illumos / Solaris.
 - Ensure strings passed from Lua to the logger are escaped (#864).
+- Handle Mongo Date / ISODate datatype properly in Lua / vmq_diversity
+  (#857).
 
 ## VerneMQ 1.5.0
 


### PR DESCRIPTION
Fixes #857 