### PR TITLE
Implement bridge queueing mechanism

### DIFF
--- a/apps/vmq_bridge/priv/vmq_bridge.schema
+++ b/apps/vmq_bridge/priv/vmq_bridge.schema
@@ -155,7 +155,25 @@
                                                                    {default, on},
                                                                    hidden
                                                                   ]}.
-%% @doc The cafile is used to define the path to a file containing 
+
+%% @doc Maximum number of outgoing messages the bridge will buffer
+%% while not connected to the remote broker. Messages published while
+%% the buffer is full are dropped. A value of 0 means buffering is
+%% disabled.
+{mapping, "vmq_bridge.tcp.$name.max_outgoing_buffered_messages", "vmq_bridge.config", [
+                                                                {datatype, integer},
+                                                                {default, 0},
+                                                                {include_default, "br0"},
+                                                                {commented, 0}
+                                                               ]}.
+
+{mapping, "vmq_bridge.ssl.$name.max_outgoing_buffered_messages", "vmq_bridge.config", [
+                                                                   {datatype, integer},
+                                                                   {default, 0},
+                                                                   hidden
+                                                                  ]}.
+
+%% @doc The cafile is used to define the path to a file containing
 %% the PEM encoded CA certificates that are trusted. 
 {mapping, "vmq_bridge.ssl.$name.cafile", "vmq_bridge.config", [
                                                               {default, ""},
@@ -305,7 +323,8 @@
                     end,
 
          Mappings = ["clean_session", "client_id", "keepalive_interval", 
-                    "username", "password", "restart_timeout", "try_private", "topic"],
+                    "username", "password", "restart_timeout", "try_private", "topic",
+                     "max_outgoing_buffered_messages"],
                     %% SSL specific
          SSLMapps = ["cafile", "capath", "certfile", "keyfile", "insecure", "tls_version", "identity", "psk"],
          F = fun(Prefix, Suffix, Validator) ->
@@ -357,6 +376,7 @@
          {TCPIPs, TCPPasswords} = lists:unzip(F("vmq_bridge.tcp", "password", StringVal)),
          {TCPIPs, TCPRestartTimeouts} = lists:unzip(F("vmq_bridge.tcp", "restart_timeout", IntVal)),
          {TCPIPs, TCPTryPrivates} = lists:unzip(F("vmq_bridge.tcp", "try_private", BoolVal)),
+         {TCPIPs, TCPMaxBuffer} = lists:unzip(F("vmq_bridge.tcp", "max_outgoing_buffered_messages", IntVal)),
          {TCPIPs, TCPTopics} = lists:unzip(F("vmq_bridge.tcp", "topic", TopicVal)),
 
          {SSLIPs, SSLCleanSessions} = lists:unzip(F("vmq_bridge.ssl", "cleansession", BoolVal)),
@@ -366,6 +386,7 @@
          {SSLIPs, SSLPasswords} = lists:unzip(F("vmq_bridge.ssl", "password", StringVal)),
          {SSLIPs, SSLRestartTimeouts} = lists:unzip(F("vmq_bridge.ssl", "restart_timeout", IntVal)),
          {SSLIPs, SSLTryPrivates} = lists:unzip(F("vmq_bridge.ssl", "try_private", BoolVal)),
+         {SSLIPs, SSLMaxBuffer} = lists:unzip(F("vmq_bridge.ssl", "max_outgoing_buffered_messages", IntVal)),
          {SSLIPs, SSLTopics} = lists:unzip(F("vmq_bridge.ssl", "topic", TopicVal)),
 
          % SSL
@@ -385,7 +406,8 @@
                                        TCPUserNames, 
                                        TCPPasswords,
                                        TCPTryPrivates,
-                                       TCPTopics])), 
+                                       TCPMaxBuffer,
+                                       TCPTopics])),
 
          SSL = lists:zip(SSLIPs, MZip([SSLCleanSessions, 
                                        SSLClientIds, 
@@ -394,6 +416,7 @@
                                        SSLUserNames, 
                                        SSLPasswords,
                                        SSLTryPrivates,
+                                       SSLMaxBuffer,
                                        SSLTopics,
                                        SSLCAFiles, 
                                        SSLCAPaths, 
@@ -409,3 +432,8 @@
          {DropUndef(TCP), DropUndef(SSL)}
  end
 }.
+
+{mapping, "vmq_bridge.clique_lead_line", "vmq_bridge.clique_lead_line",
+ [{datatype, string},
+  hidden,
+  {default, "    bridges     Manage bridges\n"}]}.

--- a/apps/vmq_bridge/src/vmq_bridge.app.src
+++ b/apps/vmq_bridge/src/vmq_bridge.app.src
@@ -5,7 +5,8 @@
   {registered, []},
   {applications, [
                   kernel,
-                  stdlib
+                  stdlib,
+                  clique
                  ]},
   {mod, { vmq_bridge_app, []}},
   {env, [
@@ -23,6 +24,7 @@
                 %%                  {username, "my_username"}, 
                 %%                  {password, "my_password"},
                 %%                  {try_private, true|false},      % send 'MQIsdp' instead of 'MQIsdp131'
+                %%                  {max_outgoing_buffered_messages, 0},
                 %%                  {topics, [{Pattern, Direction, QoS, LocalPrefix, RemotePrefix}|...]}
                 %%   ]}
             ],

--- a/apps/vmq_bridge/src/vmq_bridge_app.erl
+++ b/apps/vmq_bridge/src/vmq_bridge_app.erl
@@ -24,6 +24,7 @@
 %% ===================================================================
 
 start(_StartType, _StartArgs) ->
+    vmq_bridge_cli:register_cli(),
     vmq_bridge_sup:start_link().
 
 stop(_State) ->

--- a/apps/vmq_bridge/src/vmq_bridge_cli.erl
+++ b/apps/vmq_bridge/src/vmq_bridge_cli.erl
@@ -1,0 +1,55 @@
+%% Copyright 2018 Octavo Labs AG Basel Switzerland (http://erl.io)
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+
+-module(vmq_bridge_cli).
+-export([register_cli/0]).
+-behaviour(clique_handler).
+
+
+register_cli() ->
+    clique:register_usage(["vmq-admin", "bridge"], bridge_usage()),
+    show_cmd().
+
+show_cmd() ->
+    Cmd = ["vmq-admin", "bridge", "show"],
+    Callback =
+        fun(_, [], []) ->
+                Table =
+                    [[
+                      {endpoint, iolist_to_binary([Host, $:, integer_to_binary(Port)])},
+                      {'buffer size', Size},
+                      {'buffer max', Max},
+                      {'buffer dropped msgs', Dropped}] ||
+                        #{host := Host,
+                          port := Port,
+                          out_buffer_size := Size,
+                          out_buffer_max_size := Max,
+                          out_buffer_dropped := Dropped} <- bridge_info()],
+                [clique_status:table(Table)];
+           (_, _, _) ->
+                Text = clique_status:text(bridge_usage()),
+                [clique_status:alert([Text])]
+        end,
+    clique:register_command(Cmd, [], [], Callback).
+
+bridge_usage() ->
+    ["vmq-admin bridge <sub-command>\n\n",
+     "  Manage VerneMQ bridges.\n\n",
+     "  Sub-commands:\n",
+     "    show        Show information about bridges\n\n",
+     "  Use --help after a sub-command for more details.\n"
+    ].
+
+bridge_info() ->
+    vmq_bridge_sup:bridge_info().

--- a/apps/vmq_bridge/test/vmq_bridge_SUITE.erl
+++ b/apps/vmq_bridge/test/vmq_bridge_SUITE.erl
@@ -1,0 +1,160 @@
+%%%-------------------------------------------------------------------
+-module(vmq_bridge_SUITE).
+
+-compile(export_all).
+-compile(nowarn_export_all).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("vmq_commons/include/vmq_types.hrl").
+
+init_per_suite(Config) ->
+    cover:start(),
+    [{ct_hooks, vmq_cth} | Config].
+
+end_per_suite(_Config) ->
+    ok.
+
+init_per_group(_GroupName, Config) ->
+    Config.
+
+end_per_group(_GroupName, _Config) ->
+    ok.
+
+init_per_testcase(_TestCase, Config) ->
+    Config.
+
+end_per_testcase(_TestCase, _Config) ->
+    application:stop(vmq_bridge),
+    ok.
+
+groups() ->
+    [
+    {mqttv4, [],
+     [
+      buffer_outgoing
+      ]
+    }].
+
+all() ->
+    [{group, mqttv4}].
+
+get_bridge_pid() ->
+    [{{vmq_bridge,"localhost",1890},Pid,worker,[vmq_bridge]}] =
+        supervisor:which_children(vmq_bridge_sup),
+    Pid.
+
+pub_to_bridge(BridgePid, Payload, QoS) ->
+    BridgePid ! {deliver, [<<"bridge">>, <<"topic">>], Payload, QoS, false, false}.
+
+buffer_outgoing(_Cfg) ->
+    %% start bridge
+    start_bridge_plugin(#{qos => 0,
+                          max_outgoing_buffered_messages => 10}),
+    BridgePid = get_bridge_pid(),
+
+    %% Publish some messages before connecting, should be queued.
+    pub_to_bridge(BridgePid, <<"m1">>, 0),
+    pub_to_bridge(BridgePid, <<"m2">>, 0),
+    pub_to_bridge(BridgePid, <<"m3">>, 0),
+    pub_to_bridge(BridgePid, <<"m4">>, 0),
+    pub_to_bridge(BridgePid, <<"m5">>, 0),
+    {ok, #{out_queue_dropped := 0,
+           out_queue_max_size := 10,
+           out_queue_size := 5}} = vmq_bridge:info(BridgePid),
+
+    %% Start the 'broker' and let the bridge connect
+    {ok, SSocket} = gen_tcp:listen(1890, [binary, {packet, raw}, {active, false}, {reuseaddr, true}]),
+    {ok, BrokerSocket} = gen_tcp:accept(SSocket, 5000),
+    Connect = packet:gen_connect("bridge-test", [{keepalive,60}, {clean_session, false},
+                                            {proto_ver, 128+3}]),
+    ok = packet:expect_packet(BrokerSocket, "connect", Connect),
+
+    %% Publish some more while in the `waiting_for_connack` state
+    pub_to_bridge(BridgePid, <<"m6">>, 0),
+    pub_to_bridge(BridgePid, <<"m7">>, 0),
+    pub_to_bridge(BridgePid, <<"m8">>, 0),
+    pub_to_bridge(BridgePid, <<"m9">>, 0),
+    pub_to_bridge(BridgePid, <<"m10">>, 0),
+    pub_to_bridge(BridgePid, <<"m11">>, 0),
+    pub_to_bridge(BridgePid, <<"m12">>, 0),
+
+    {ok, #{out_queue_dropped := 2,
+           out_queue_max_size := 10,
+           out_queue_size := 10}} = vmq_bridge:info(BridgePid),
+
+    %% Reply with the connack
+    Connack = packet:gen_connack(0),
+    ok = gen_tcp:send(BrokerSocket, Connack),
+    ExpectPub = fun(Payload) ->
+                        Pub = packet:gen_publish("bridge/topic", 0, Payload, []),
+                        ok = packet:expect_packet(BrokerSocket, "publish", Pub)
+                end,
+
+    ExpectPub(<<"m1">>),
+    ExpectPub(<<"m2">>),
+    ExpectPub(<<"m3">>),
+    ExpectPub(<<"m4">>),
+    ExpectPub(<<"m5">>),
+    ExpectPub(<<"m6">>),
+    ExpectPub(<<"m7">>),
+    ExpectPub(<<"m8">>),
+    ExpectPub(<<"m9">>),
+    ExpectPub(<<"m10">>),
+
+
+    %% After having published the buffered messages the bridge will
+    %% try to subscribe. TODO: Note this is not completely
+    %% deterministic as it could happen that the subscribe is
+    %% interleaved with the publishes above. We should fix this if
+    %% that becomes a problem.
+    Subscribe = packet:gen_subscribe(11, "bridge/#", 0),
+    ok = packet:expect_packet(BrokerSocket, "subscribe", Subscribe),
+    Suback = packet:gen_suback(11, 2),
+    ok = gen_tcp:send(BrokerSocket, Suback),
+
+    %% Everything should be flushed.
+    {ok, #{out_queue_dropped := 2,
+           out_queue_max_size := 10,
+           out_queue_size := 0}} = vmq_bridge:info(BridgePid),
+
+    ok = gen_tcp:close(BrokerSocket).
+
+start_bridge_plugin(Opts) ->
+    QoS = maps:get(qos, Opts),
+    Max = maps:get(max_outgoing_buffered_messages, Opts),
+    application:load(vmq_bridge),
+    application:set_env(vmq_bridge, registry_mfa,
+                        {?MODULE, bridge_reg, [self()]}),
+    application:set_env(vmq_bridge, config,
+                        {[
+                          %% TCP Bridges
+                          {"localhost:1890", [{topics, [{"bridge/#", both, QoS, "", ""}]},
+                                              {restart_timeout, 5},
+                                              {client_id, "bridge-test"},
+                                              {max_outgoing_buffered_messages, Max}]}
+                         ],
+                         [
+                          %% SSL Bridges
+                         ]
+                        }),
+    application:ensure_all_started(vmq_bridge),
+    Config = [{vmq_bridge, application:get_all_env(vmq_bridge)}],
+    vmq_bridge_sup:change_config(Config).
+
+bridge_reg(ReportProc) ->
+    RegisterFun = fun() ->
+                          ok
+                  end,
+    PublishFun = fun(Topic, Payload, _Opts) ->
+                         ReportProc ! {publish, Topic, Payload},
+                         ok
+                 end,
+    SubscribeFun = fun(_Topic) ->
+                           ReportProc ! {subscribe, self()},
+                           {ok, [1]}
+                   end,
+    UnsubscribeFun = fun(_Topic) ->
+                             ReportProc ! {unsubscribe, self()},
+                             ok
+                     end,
+    {RegisterFun, PublishFun, {SubscribeFun, UnsubscribeFun}}.

--- a/apps/vmq_commons/src/packet.erl
+++ b/apps/vmq_commons/src/packet.erl
@@ -25,7 +25,7 @@
 expect_packet(Socket, Name, Expected) ->
     expect_packet(gen_tcp, Socket, Name, Expected).
 expect_packet(Transport, Socket, Name, Expected) ->
-    expect_packet(Transport, Socket, Name, Expected, 60000).
+    expect_packet(Transport, Socket, Name, Expected, 5000).
 expect_packet(Transport, Socket, _Name, Expected, Timeout) ->
     RLen =
     case byte_size(Expected) of

--- a/changelog.md
+++ b/changelog.md
@@ -84,6 +84,11 @@
   version 3.6.0 and `lager` to version 3.6.3. We also removed the `eper`
   dependency and suppressed some new warnings due to `erlang:get_stacktrace/0`
   having been deprecated in Erlang/OTP 21.
+- The bridge plugin (`vmq_bridge`) now has an option to queue outgoing message
+  in case the network connection disappears. This is configurable with the
+  `max_outgoing_buffered_messages` setting on a bridge. In addition the bridge
+  now has a simple cli interface under `vmq-admin bridge show`. This work was
+  kindly sponsored by Diacare-Soft(http://diacare-soft.ru).
 
 ## VerneMQ 1.5.0
 


### PR DESCRIPTION
Note, since the last internal review I changed the cli from `vmq-admin bridges show` to `vmq-admin bridge show`. Everything else is singular (except metrics), and `bridges` just felt wrong...