### PR TITLE
Hide unused config

### DIFF
--- a/apps/vmq_bridge/docs/vmq_bridge.rst
+++ b/apps/vmq_bridge/docs/vmq_bridge.rst
@@ -75,8 +75,6 @@ SSL bridges support the same configuration parameters as TCP bridges, but need f
     # define the CA certificate file or the path to the
     # installed CA certificates
     bridge.ssl.br0.cafile = cafile.crt
-    #or
-    bridge.ssl.br0.capath = /path/to/cacerts
 
     # if the remote broker requires client certificate authentication
     bridge.ssl.br0.certfile = /path/to/certfile.pem

--- a/apps/vmq_bridge/priv/vmq_bridge.schema
+++ b/apps/vmq_bridge/priv/vmq_bridge.schema
@@ -185,10 +185,12 @@
 %% @doc Define the path to a folder containing 
 %% the PEM encoded CA certificates that are trusted. 
 {mapping, "vmq_bridge.ssl.$name.capath", "vmq_bridge.config", [
-                                                              {default, ""},
-                                                              {datatype, file},
-                                                              {include_default, "sbr0"},
-                                                              {commented, "{{platform_etc_dir}}/cacerts"}
+                                                               %% TODO: this option isn't implemented in the bridge and should be fully removed on VerneMQ 2.0
+                                                               {default, ""},
+                                                               {datatype, file},
+                                                               {include_default, "sbr0"},
+                                                               {commented, "{{platform_etc_dir}}/cacerts"},
+                                                               hidden
                                                              ]}. 
 
 %% @doc Set the path to the PEM encoded server certificate.
@@ -326,7 +328,7 @@
                     "username", "password", "restart_timeout", "try_private", "topic",
                      "max_outgoing_buffered_messages"],
                     %% SSL specific
-         SSLMapps = ["cafile", "capath", "certfile", "keyfile", "insecure", "tls_version", "identity", "psk"],
+         SSLMapps = ["cafile", "certfile", "keyfile", "insecure", "tls_version", "identity", "psk"],
          F = fun(Prefix, Suffix, Validator) ->
                      %% get the name value pairs
                      Prefix3 = lists:flatten([Prefix, ".$name"]),
@@ -391,7 +393,6 @@
 
          % SSL
          {SSLIPs, SSLCAFiles} = lists:unzip(F("vmq_bridge.ssl", "cafile", StringVal)),
-         {SSLIPs, SSLCAPaths} = lists:unzip(F("vmq_bridge.ssl", "capath", StringVal)),
          {SSLIPs, SSLCertFiles} = lists:unzip(F("vmq_bridge.ssl", "certfile", StringVal)),
          {SSLIPs, SSLKeyFiles} = lists:unzip(F("vmq_bridge.ssl", "keyfile", StringVal)),
          {SSLIPs, SSLInsecures} = lists:unzip(F("vmq_bridge.ssl", "insecure", BoolVal)),
@@ -419,8 +420,7 @@
                                        SSLMaxBuffer,
                                        SSLTopics,
                                        SSLCAFiles, 
-                                       SSLCAPaths, 
-                                       SSLCertFiles, 
+                                       SSLCertFiles,
                                        SSLKeyFiles, 
                                        SSLInsecures, 
                                        SSLVersions, 

--- a/apps/vmq_server/src/vmq_schema.erl
+++ b/apps/vmq_server/src/vmq_schema.erl
@@ -116,7 +116,6 @@ translate_listeners(Conf) ->
 
                                                 % SSL
     {SSLIPs, SSLCAFiles} = lists:unzip(extract("listener.ssl", "cafile", StrVal, Conf)),
-    {SSLIPs, SSLCAPaths} = lists:unzip(extract("listener.ssl", "capath", StrVal, Conf)),
     {SSLIPs, SSLDepths} = lists:unzip(extract("listener.ssl", "depth", IntVal, Conf)),
     {SSLIPs, SSLCertFiles} = lists:unzip(extract("listener.ssl", "certfile", StrVal, Conf)),
     {SSLIPs, SSLCiphers} = lists:unzip(extract("listener.ssl", "ciphers", StrVal, Conf)),
@@ -128,7 +127,6 @@ translate_listeners(Conf) ->
 
                                                 % WSS
     {WS_SSLIPs, WS_SSLCAFiles} = lists:unzip(extract("listener.wss", "cafile", StrVal, Conf)),
-    {WS_SSLIPs, WS_SSLCAPaths} = lists:unzip(extract("listener.wss", "capath", StrVal, Conf)),
     {WS_SSLIPs, WS_SSLDepths} = lists:unzip(extract("listener.wss", "depth", IntVal, Conf)),
     {WS_SSLIPs, WS_SSLCertFiles} = lists:unzip(extract("listener.wss", "certfile", StrVal, Conf)),
     {WS_SSLIPs, WS_SSLCiphers} = lists:unzip(extract("listener.wss", "ciphers", StrVal, Conf)),
@@ -140,7 +138,6 @@ translate_listeners(Conf) ->
 
                                                 % VMQS
     {VMQ_SSLIPs, VMQ_SSLCAFiles} = lists:unzip(extract("listener.vmqs", "cafile", StrVal, Conf)),
-    {VMQ_SSLIPs, VMQ_SSLCAPaths} = lists:unzip(extract("listener.vmqs", "capath", StrVal, Conf)),
     {VMQ_SSLIPs, VMQ_SSLDepths} = lists:unzip(extract("listener.vmqs", "depth", IntVal, Conf)),
     {VMQ_SSLIPs, VMQ_SSLCertFiles} = lists:unzip(extract("listener.vmqs", "certfile", StrVal, Conf)),
     {VMQ_SSLIPs, VMQ_SSLCiphers} = lists:unzip(extract("listener.vmqs", "ciphers", StrVal, Conf)),
@@ -151,7 +148,6 @@ translate_listeners(Conf) ->
 
                                                 % HTTPS
     {HTTP_SSLIPs, HTTP_SSLCAFiles} = lists:unzip(extract("listener.https", "cafile", StrVal, Conf)),
-    {HTTP_SSLIPs, HTTP_SSLCAPaths} = lists:unzip(extract("listener.https", "capath", StrVal, Conf)),
     {HTTP_SSLIPs, HTTP_SSLDepths} = lists:unzip(extract("listener.https", "depth", IntVal, Conf)),
     {HTTP_SSLIPs, HTTP_SSLCertFiles} = lists:unzip(extract("listener.https", "certfile", StrVal, Conf)),
     {HTTP_SSLIPs, HTTP_SSLCiphers} = lists:unzip(extract("listener.https", "ciphers", StrVal, Conf)),
@@ -183,7 +179,6 @@ translate_listeners(Conf) ->
                                   SSLNrOfAcceptors,
                                   SSLMountPoint,
                                   SSLCAFiles,
-                                  SSLCAPaths,
                                   SSLDepths,
                                   SSLCertFiles,
                                   SSLCiphers,
@@ -197,7 +192,6 @@ translate_listeners(Conf) ->
                                      WS_SSLNrOfAcceptors,
                                      WS_SSLMountPoint,
                                      WS_SSLCAFiles,
-                                     WS_SSLCAPaths,
                                      WS_SSLDepths,
                                      WS_SSLCertFiles,
                                      WS_SSLCiphers,
@@ -211,7 +205,6 @@ translate_listeners(Conf) ->
                                        VMQ_SSLNrOfAcceptors,
                                        VMQ_SSLMountPoint,
                                        VMQ_SSLCAFiles,
-                                       VMQ_SSLCAPaths,
                                        VMQ_SSLDepths,
                                        VMQ_SSLCertFiles,
                                        VMQ_SSLCiphers,
@@ -222,7 +215,6 @@ translate_listeners(Conf) ->
     HTTPS = lists:zip(HTTP_SSLIPs, MZip([HTTP_SSLMaxConns,
                                          HTTP_SSLNrOfAcceptors,
                                          HTTP_SSLCAFiles,
-                                         HTTP_SSLCAPaths,
                                          HTTP_SSLDepths,
                                          HTTP_SSLCertFiles,
                                          HTTP_SSLCiphers,
@@ -250,7 +242,7 @@ extract(Prefix, Suffix, Val, Conf) ->
     Mappings = ["max_connections", "nr_of_acceptors", "mountpoint"],
     ExcludeRootSuffixes
         = [%% ssl listener specific
-           "cafile", "capath", "depth", "certfile", "ciphers", "crlfile",
+           "cafile", "depth", "certfile", "ciphers", "crlfile",
            "keyfile", "require_certificate", "tls_version",
            "use_identity_as_username",
            %% http listener specific

--- a/changelog.md
+++ b/changelog.md
@@ -94,6 +94,8 @@
 - Add experimental `vmq_swc` plugin that provides an alternative to the existing
   `vmq_plumtree` for metadata storage and replication. One must compile VerneMQ
   with `make swc` to generate a release containing the `vmq_swc` plugin.
+- Remove unused `vmq_bridge` ssl `capath` config option. This was never used
+  internally.
 
 ## VerneMQ 1.5.0
 


### PR DESCRIPTION
This hides the bridge capath option as this was never used internally anyway - so that was just confusing.

As we never exposed the capath for ssl listeners in the vmq_server schema I've also removed the capath handling code.